### PR TITLE
Add immediateUpdateOnRuntimeChange option to capacitor plugin

### DIFF
--- a/packages/capacitor-plugin/README.md
+++ b/packages/capacitor-plugin/README.md
@@ -51,6 +51,7 @@ plugins: {
     // channel: "staging",
     // runtimeVersion: "2026.04",
     // updateMode: "next-resume",
+    // immediateUpdateOnRuntimeChange: true,
     // updateMode: "manual",
     // updateMode: "immediate",
   }
@@ -83,6 +84,17 @@ When `runtimeVersion` is set:
 - the plugin requests bundle updates only for that runtime lane
 - bundle uploads inherit the same runtime value automatically through the CLI
 - releases stay simple: publish the bundle, and it naturally stays inside its own runtime lane
+
+If you also set `immediateUpdateOnRuntimeChange: true`, OtaKit treats a fresh
+install or a new `runtimeVersion` as a one-time startup override in automatic
+`next-launch` / `next-resume` mode:
+
+- it skips normal staged-on-launch activation once
+- it bypasses `checkInterval`
+- it checks live on cold start and applies immediately if a newer bundle exists
+
+That gives new installs and new native shells a faster catch-up path without
+changing normal resume behavior.
 
 ## Trust model
 
@@ -124,7 +136,6 @@ resume**.
 - `immediate`
   checks, downloads, and activates in one shot as soon as possible on cold start and resume (the user may briefly see the previous version before a reload).
   primarily for development and testing — not recommended for production.
-
 
 ## Runtime model
 
@@ -173,6 +184,10 @@ The plugin handles checking, downloading, activation, and rollback based on
 `updateMode`. In `next-launch` and `next-resume`, it checks on cold start and
 every time the app comes back from the background, throttled by `checkInterval`.
 `immediate` bypasses that throttle.
+
+If `immediateUpdateOnRuntimeChange` is enabled, the first cold start for a new
+runtime lane also bypasses the throttle and uses an immediate-style launch
+check. After that first lane resolution, normal mode behavior resumes.
 
 For most apps, this is the entire runtime integration.
 

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/BundleStore.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/BundleStore.java
@@ -21,6 +21,7 @@ final class BundleStore {
   private static final String KEY_FALLBACK = "fallback_bundle_id";
   private static final String KEY_STAGED = "staged_bundle_id";
   private static final String KEY_FAILED_INFO = "failed_bundle_info";
+  private static final String KEY_LAST_RESOLVED_RUNTIME_KEY = "last_resolved_runtime_key";
 
   private final Context context;
   private final SharedPreferences prefs;
@@ -29,7 +30,12 @@ final class BundleStore {
   private final String nativeBuild;
   private final String appRuntimeVersion;
 
-  BundleStore(Context context, String builtinVersion, String nativeBuild, String appRuntimeVersion) {
+  BundleStore(
+    Context context,
+    String builtinVersion,
+    String nativeBuild,
+    String appRuntimeVersion
+  ) {
     this.context = context.getApplicationContext();
     this.prefs = this.context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
     this.builtinVersion = builtinVersion;
@@ -201,6 +207,21 @@ final class BundleStore {
     } catch (Exception e) {
       return null;
     }
+  }
+
+  synchronized String getLastResolvedRuntimeKey() {
+    return prefs.getString(KEY_LAST_RESOLVED_RUNTIME_KEY, null);
+  }
+
+  synchronized void setLastResolvedRuntimeKey(String runtimeKey) {
+    SharedPreferences.Editor editor = prefs.edit();
+    if (runtimeKey == null) {
+      // null clears the key so the next cold start is treated as unresolved again
+      editor.remove(KEY_LAST_RESOLVED_RUNTIME_KEY);
+    } else {
+      editor.putString(KEY_LAST_RESOLVED_RUNTIME_KEY, runtimeKey);
+    }
+    editor.commit();
   }
 
   synchronized void markStatus(String bundleId, BundleStatus status) {

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
@@ -41,6 +41,7 @@ public class UpdaterPlugin extends Plugin {
   private String appId;
   private String channel;
   private String runtimeVersion;
+  private boolean immediateUpdateOnRuntimeChange = false;
   private java.util.List<ManifestVerifier.KeyEntry> manifestKeys = new java.util.ArrayList<>();
   private long checkIntervalMs = 600_000;
   private final AtomicBoolean checkInProgress = new AtomicBoolean(false);
@@ -52,6 +53,7 @@ public class UpdaterPlugin extends Plugin {
   private static final String UPDATE_MODE_NEXT_RESUME = "next-resume";
   private static final String UPDATE_MODE_IMMEDIATE = "immediate";
   private static final String KEY_LAST_CHECK_TIMESTAMP = "last_check_timestamp";
+  private static final String DEFAULT_RUNTIME_KEY = "__default__";
   private static final String TRIGGER_LAUNCH = "launch";
   private static final String TRIGGER_RESUME = "resume";
 
@@ -78,10 +80,7 @@ public class UpdaterPlugin extends Plugin {
       getConfig().getString("ingestUrl"),
       System.getenv("OTAKIT_INGEST_URL")
     );
-    this.cdnUrl = resolveCdnUrl(
-      getConfig().getString("cdnUrl"),
-      System.getenv("OTAKIT_CDN_URL")
-    );
+    this.cdnUrl = resolveCdnUrl(getConfig().getString("cdnUrl"), System.getenv("OTAKIT_CDN_URL"));
     this.appId = getConfig().getString("appId");
     this.channel = trimToNull(getConfig().getString("channel"));
     this.runtimeVersion = trimToNull(getConfig().getString("runtimeVersion"));
@@ -89,6 +88,10 @@ public class UpdaterPlugin extends Plugin {
     this.allowInsecureUrls = getConfig().getBoolean("allowInsecureUrls", false);
     String configuredUpdateMode = getConfig().getString("updateMode", UPDATE_MODE_NEXT_LAUNCH);
     this.updateMode = resolveUpdateMode(configuredUpdateMode);
+    this.immediateUpdateOnRuntimeChange = getConfig().getBoolean(
+      "immediateUpdateOnRuntimeChange",
+      false
+    );
 
     try {
       org.json.JSONArray rawKeys = getConfig().getConfigJSON().optJSONArray("manifestKeys");
@@ -137,7 +140,9 @@ public class UpdaterPlugin extends Plugin {
       current = store.getCurrentBundle();
     }
 
-    if (shouldActivateStagedOnLaunch()) {
+    boolean forceImmediateRuntimeChangeLaunch = shouldForceImmediateRuntimeChangeLaunch();
+
+    if (!forceImmediateRuntimeChangeLaunch && shouldActivateStagedOnLaunch()) {
       current = activateStagedBundleForLaunch();
     }
 
@@ -153,7 +158,7 @@ public class UpdaterPlugin extends Plugin {
     }
 
     if (isAutomaticUpdateMode()) {
-      runAutomaticUpdate(TRIGGER_LAUNCH);
+      runAutomaticUpdate(TRIGGER_LAUNCH, forceImmediateRuntimeChangeLaunch);
     }
   }
 
@@ -161,17 +166,19 @@ public class UpdaterPlugin extends Plugin {
   protected void handleOnResume() {
     super.handleOnResume();
     if (isAutomaticUpdateMode()) {
-      runAutomaticUpdate(TRIGGER_RESUME);
+      runAutomaticUpdate(TRIGGER_RESUME, false);
     }
   }
 
-  private void runAutomaticUpdate(String trigger) {
+  private void runAutomaticUpdate(String trigger, boolean forceImmediateLaunch) {
     // Resume-only guards
     if (TRIGGER_RESUME.equals(trigger)) {
       if (UPDATE_MODE_MANUAL.equals(updateMode)) return;
 
       // next-resume and immediate: activate staged bundle on resume without server check
-      if ((UPDATE_MODE_NEXT_RESUME.equals(updateMode) || UPDATE_MODE_IMMEDIATE.equals(updateMode))) {
+      if (
+        (UPDATE_MODE_NEXT_RESUME.equals(updateMode) || UPDATE_MODE_IMMEDIATE.equals(updateMode))
+      ) {
         String stagedId = store.getStagedBundleId();
         if (stagedId != null && store.getBundle(stagedId) != null) {
           activateStagedBundleForReload();
@@ -185,6 +192,7 @@ public class UpdaterPlugin extends Plugin {
 
     if (
       TRIGGER_LAUNCH.equals(trigger) &&
+      !forceImmediateLaunch &&
       !UPDATE_MODE_IMMEDIATE.equals(updateMode) &&
       shouldThrottleCheck()
     ) {
@@ -194,17 +202,26 @@ public class UpdaterPlugin extends Plugin {
     // Acquire in-flight guard (submit-time)
     if (!checkInProgress.compareAndSet(false, true)) return;
 
-    if (UPDATE_MODE_IMMEDIATE.equals(updateMode)) {
+    if (forceImmediateLaunch || UPDATE_MODE_IMMEDIATE.equals(updateMode)) {
       // Immediate: check+download, activate if found
       executor.execute(() -> {
         try {
           BundleInfo result = performCheckAndDownload(null, true);
           if (result != null) {
+            if (forceImmediateLaunch) {
+              recordCheckTimestamp();
+            }
             activateStagedBundleForReload();
             reloadWebView();
+          } else if (forceImmediateLaunch) {
+            resolveCurrentRuntimeKey();
+            recordCheckTimestamp();
           }
         } catch (Exception e) {
-          android.util.Log.w("OtaKit", "immediate update failed (" + trigger + ")", e);
+          String reason = forceImmediateLaunch
+            ? "runtime-change startup update failed"
+            : "immediate update failed (" + trigger + ")";
+          android.util.Log.w("OtaKit", reason, e);
         } finally {
           checkInProgress.set(false);
         }
@@ -233,9 +250,7 @@ public class UpdaterPlugin extends Plugin {
   }
 
   private void recordCheckTimestamp() {
-    store.getPrefs().edit()
-      .putLong(KEY_LAST_CHECK_TIMESTAMP, System.currentTimeMillis())
-      .apply();
+    store.getPrefs().edit().putLong(KEY_LAST_CHECK_TIMESTAMP, System.currentTimeMillis()).apply();
   }
 
   private boolean shouldActivateStagedOnLaunch() {
@@ -244,6 +259,35 @@ public class UpdaterPlugin extends Plugin {
 
   private boolean isAutomaticUpdateMode() {
     return !UPDATE_MODE_MANUAL.equals(updateMode);
+  }
+
+  private boolean shouldForceImmediateRuntimeChangeLaunch() {
+    if (!immediateUpdateOnRuntimeChange) {
+      return false;
+    }
+    if (UPDATE_MODE_MANUAL.equals(updateMode)) {
+      android.util.Log.w(
+        "OtaKit",
+        "immediateUpdateOnRuntimeChange is ignored when updateMode is manual"
+      );
+      return false;
+    }
+    if (UPDATE_MODE_IMMEDIATE.equals(updateMode)) {
+      android.util.Log.w(
+        "OtaKit",
+        "immediateUpdateOnRuntimeChange is ignored when updateMode is immediate"
+      );
+      return false;
+    }
+    return !java.util.Objects.equals(store.getLastResolvedRuntimeKey(), currentRuntimeKey());
+  }
+
+  private String currentRuntimeKey() {
+    return runtimeVersion != null ? runtimeVersion : DEFAULT_RUNTIME_KEY;
+  }
+
+  private void resolveCurrentRuntimeKey() {
+    store.setLastResolvedRuntimeKey(currentRuntimeKey());
   }
 
   private String resolveUpdateMode(String configuredUpdateMode) {
@@ -265,10 +309,7 @@ public class UpdaterPlugin extends Plugin {
       return UPDATE_MODE_IMMEDIATE;
     }
 
-    android.util.Log.w(
-      "OtaKit",
-      "Unknown updateMode '" + raw + "', defaulting to 'next-launch'"
-    );
+    android.util.Log.w("OtaKit", "Unknown updateMode '" + raw + "', defaulting to 'next-launch'");
     return UPDATE_MODE_NEXT_LAUNCH;
   }
 
@@ -326,6 +367,8 @@ public class UpdaterPlugin extends Plugin {
         if (latest == null) {
           call.resolve((JSObject) null);
         } else if (isCurrentBundleLatest(latest, targetChannel)) {
+          call.resolve((JSObject) null);
+        } else if (shouldSuppressLatestManifest(latest, targetChannel)) {
           call.resolve((JSObject) null);
         } else {
           BundleInfo staged = findMatchingStagedBundle(latest, targetChannel);
@@ -468,6 +511,13 @@ public class UpdaterPlugin extends Plugin {
       return null;
     }
 
+    if (shouldSuppressLatestManifest(latest, targetChannel)) {
+      if (emitEvents) {
+        notifyListeners("noUpdateAvailable", new JSObject());
+      }
+      return null;
+    }
+
     BundleInfo staged = findMatchingStagedBundle(latest, targetChannel);
     if (emitEvents) {
       notifyListeners("updateAvailable", manifestToJSObject(latest, staged != null));
@@ -477,33 +527,7 @@ public class UpdaterPlugin extends Plugin {
       return staged;
     }
 
-    try {
-      return downloadAndStage(
-        new URL(latest.url),
-        latest.version,
-        latest.sha256,
-        latest.size,
-        latest.runtimeVersion,
-        targetChannel,
-        latest.releaseId
-      );
-    } catch (Exception e) {
-      if (isExpiredURLError(e)) {
-        // Download URL may have expired — re-fetch manifest once and retry
-        ManifestClient.LatestManifest refreshed = fetchLatest(targetChannel);
-        if (refreshed == null) throw e;
-        return downloadAndStage(
-          new URL(refreshed.url),
-          refreshed.version,
-          refreshed.sha256,
-          refreshed.size,
-          refreshed.runtimeVersion,
-          targetChannel,
-          refreshed.releaseId
-        );
-      }
-      throw e;
-    }
+    return downloadLatestManifest(latest, targetChannel);
   }
 
   private boolean isExpiredURLError(Exception e) {
@@ -604,7 +628,14 @@ public class UpdaterPlugin extends Plugin {
       failed.put("version", version);
       failed.put("error", e.getMessage());
       notifyListeners("downloadFailed", failed);
-      sendDeviceEvent("download_error", version, runtimeVersion, channel, releaseId, e.getMessage());
+      sendDeviceEvent(
+        "download_error",
+        version,
+        runtimeVersion,
+        channel,
+        releaseId,
+        e.getMessage()
+      );
       throw e;
     } finally {
       if (downloadedZip != null && downloadedZip.exists()) {
@@ -686,6 +717,7 @@ public class UpdaterPlugin extends Plugin {
       return store.getCurrentBundle();
     }
 
+    resolveCurrentRuntimeKey();
     store.setCurrentBundleId(staged.id);
     store.setStagedBundleId(null);
     return staged;
@@ -709,6 +741,7 @@ public class UpdaterPlugin extends Plugin {
       return;
     }
 
+    resolveCurrentRuntimeKey();
     store.setCurrentBundleId(staged.id);
     store.setStagedBundleId(null);
 
@@ -856,6 +889,45 @@ public class UpdaterPlugin extends Plugin {
     return doesBundleMatchLatest(store.getCurrentBundle(), latest, targetChannel);
   }
 
+  private boolean shouldSuppressLatestManifest(
+    ManifestClient.LatestManifest latest,
+    String targetChannel
+  ) {
+    BundleInfo failed = store.getFailedBundle();
+    return failed != null && doesFailedBundleMatchLatest(failed, latest, targetChannel);
+  }
+
+  private boolean doesFailedBundleMatchLatest(
+    BundleInfo failed,
+    ManifestClient.LatestManifest latest,
+    String targetChannel
+  ) {
+    if (!java.util.Objects.equals(trimToNull(failed.channel), targetChannel)) {
+      return false;
+    }
+    if (
+      !java.util.Objects.equals(
+        trimToNull(failed.runtimeVersion),
+        trimToNull(latest.runtimeVersion)
+      )
+    ) {
+      return false;
+    }
+    if (
+      latest.releaseId != null &&
+      failed.releaseId != null &&
+      latest.releaseId.equals(failed.releaseId)
+    ) {
+      return true;
+    }
+    return (
+      latest.sha256 != null &&
+      failed.sha256 != null &&
+      !latest.sha256.isEmpty() &&
+      latest.sha256.equals(failed.sha256)
+    );
+  }
+
   private boolean doesBundleMatchLatest(
     BundleInfo bundle,
     ManifestClient.LatestManifest latest,
@@ -886,11 +958,7 @@ public class UpdaterPlugin extends Plugin {
       return true;
     }
 
-    if (
-      latest.sha256 != null &&
-      bundle.sha256 != null &&
-      latest.sha256.equals(bundle.sha256)
-    ) {
+    if (latest.sha256 != null && bundle.sha256 != null && latest.sha256.equals(bundle.sha256)) {
       return true;
     }
 
@@ -916,11 +984,50 @@ public class UpdaterPlugin extends Plugin {
       return null;
     }
 
-    if (!java.util.Objects.equals(trimToNull(staged.runtimeVersion), trimToNull(latest.runtimeVersion))) {
+    if (
+      !java.util.Objects.equals(
+        trimToNull(staged.runtimeVersion),
+        trimToNull(latest.runtimeVersion)
+      )
+    ) {
       return null;
     }
 
     return doesBundleMatchLatest(staged, latest, targetChannel) ? staged : null;
+  }
+
+  private BundleInfo downloadLatestManifest(
+    ManifestClient.LatestManifest latest,
+    String targetChannel
+  ) throws Exception {
+    try {
+      return downloadAndStage(
+        new URL(latest.url),
+        latest.version,
+        latest.sha256,
+        latest.size,
+        latest.runtimeVersion,
+        targetChannel,
+        latest.releaseId
+      );
+    } catch (Exception e) {
+      if (isExpiredURLError(e)) {
+        ManifestClient.LatestManifest refreshed = fetchLatest(targetChannel);
+        if (refreshed == null) {
+          throw e;
+        }
+        return downloadAndStage(
+          new URL(refreshed.url),
+          refreshed.version,
+          refreshed.sha256,
+          refreshed.size,
+          refreshed.runtimeVersion,
+          targetChannel,
+          refreshed.releaseId
+        );
+      }
+      throw e;
+    }
   }
 
   private void moveDirectory(File source, File destination) throws Exception {

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/BundleStore.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/BundleStore.swift
@@ -6,6 +6,7 @@ final class BundleStore {
     static let fallbackBundleId = "otakit_fallback_bundle_id"
     static let stagedBundleId = "otakit_staged_bundle_id"
     static let failedBundleInfo = "otakit_failed_bundle_info"
+    static let lastResolvedRuntimeKey = "otakit_last_resolved_runtime_key"
   }
 
   private let defaults = UserDefaults.standard
@@ -195,6 +196,19 @@ final class BundleStore {
       return nil
     }
     return try? decoder.decode(BundleInfo.self, from: data)
+  }
+
+  func getLastResolvedRuntimeKey() -> String? {
+    defaults.string(forKey: Keys.lastResolvedRuntimeKey)
+  }
+
+  func setLastResolvedRuntimeKey(_ runtimeKey: String?) {
+    if let runtimeKey {
+      defaults.set(runtimeKey, forKey: Keys.lastResolvedRuntimeKey)
+    } else {
+      // nil clears the key so the next cold start is treated as unresolved again
+      defaults.removeObject(forKey: Keys.lastResolvedRuntimeKey)
+    }
   }
 
   func markStatus(bundleId: String, status: BundleStatus) {

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
@@ -40,6 +40,7 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
   private var appId: String?
   private var channel: String?
   private var runtimeVersion: String?
+  private var immediateUpdateOnRuntimeChange = false
   private var manifestKeys: [(kid: String, key: Data)] = []
   private var trialTimeoutWorkItem: DispatchWorkItem?
   private var checkIntervalMs: Int = 600_000
@@ -50,6 +51,7 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
   private static let defaultCdnURL = "https://cdn.otakit.app"
   private static let ingestPathSuffix = "/v1"
   private static let lastCheckTimestampKey = "otakit_last_check_timestamp"
+  private static let defaultRuntimeKey = "__default__"
 
   public override func load() {
     let envIngestUrl = ProcessInfo.processInfo.environment["OTAKIT_INGEST_URL"]
@@ -69,6 +71,7 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     allowInsecureUrls = getConfig().getBoolean("allowInsecureUrls", false)
     let updateModeRaw = getConfig().getString("updateMode", UpdateMode.nextLaunch.rawValue)
     updateMode = resolveUpdateMode(configured: updateModeRaw)
+    immediateUpdateOnRuntimeChange = getConfig().getBoolean("immediateUpdateOnRuntimeChange", false)
     downloader = Downloader(allowInsecureUrls: allowInsecureUrls)
     appReadyTimeoutMs = max(1000, getConfig().getInt("appReadyTimeout", 10_000))
     checkIntervalMs = max(600_000, getConfig().getInt("checkInterval", 600_000))
@@ -102,7 +105,9 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
       current = store.getCurrentBundle()
     }
 
-    if shouldActivateStagedOnLaunch() {
+    let forceImmediateRuntimeChangeLaunch = shouldForceImmediateRuntimeChangeLaunch()
+
+    if !forceImmediateRuntimeChangeLaunch && shouldActivateStagedOnLaunch() {
       current = activateStagedBundleForLaunch()
     }
 
@@ -118,7 +123,10 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     if isAutomaticUpdateMode() {
-      runAutomaticUpdate(trigger: .launch)
+      runAutomaticUpdate(
+        trigger: .launch,
+        forceImmediateLaunch: forceImmediateRuntimeChangeLaunch
+      )
     }
 
     if isAutomaticUpdateMode() {
@@ -139,10 +147,10 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
   }
 
   private func handleAppWillEnterForeground() {
-    runAutomaticUpdate(trigger: .resume)
+    runAutomaticUpdate(trigger: .resume, forceImmediateLaunch: false)
   }
 
-  private func runAutomaticUpdate(trigger: Trigger) {
+  private func runAutomaticUpdate(trigger: Trigger, forceImmediateLaunch: Bool) {
     // Resume-only guards
     if trigger == .resume {
       if updateMode == .manual { return }
@@ -159,7 +167,11 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
       if updateMode != .immediate && shouldThrottleCheck() { return }
     }
 
-    if trigger == .launch && updateMode != .immediate && shouldThrottleCheck() {
+    if trigger == .launch &&
+      !forceImmediateLaunch &&
+      updateMode != .immediate &&
+      shouldThrottleCheck()
+    {
       return
     }
 
@@ -167,17 +179,27 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     guard claimCheckInProgress() else { return }
 
     // Immediate mode on cold start: block until check+download+activate completes
-    if updateMode == .immediate && trigger == .launch {
+    if (updateMode == .immediate && trigger == .launch) || forceImmediateLaunch {
       Task {
         defer { releaseCheckInProgress() }
         do {
           let result = try await performCheckAndDownload(channel: nil, emitEvents: true)
           if result != nil {
+            if forceImmediateLaunch {
+              recordCheckTimestamp()
+            }
             activateStagedBundleForReload()
             reloadWebView()
+          } else if forceImmediateLaunch {
+            resolveCurrentRuntimeKey()
+            recordCheckTimestamp()
           }
         } catch {
-          print("[OtaKit] immediate startup update failed: \(error.localizedDescription)")
+          if forceImmediateLaunch {
+            print("[OtaKit] runtime-change startup update failed: \(error.localizedDescription)")
+          } else {
+            print("[OtaKit] immediate startup update failed: \(error.localizedDescription)")
+          }
         }
       }
       return
@@ -248,6 +270,29 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     updateMode != .manual
   }
 
+  private func shouldForceImmediateRuntimeChangeLaunch() -> Bool {
+    guard immediateUpdateOnRuntimeChange else {
+      return false
+    }
+    if updateMode == .manual {
+      print("[OtaKit] immediateUpdateOnRuntimeChange is ignored when updateMode is manual")
+      return false
+    }
+    if updateMode == .immediate {
+      print("[OtaKit] immediateUpdateOnRuntimeChange is ignored when updateMode is immediate")
+      return false
+    }
+    return store.getLastResolvedRuntimeKey() != currentRuntimeKey()
+  }
+
+  private func currentRuntimeKey() -> String {
+    runtimeVersion ?? UpdaterPlugin.defaultRuntimeKey
+  }
+
+  private func resolveCurrentRuntimeKey() {
+    store.setLastResolvedRuntimeKey(currentRuntimeKey())
+  }
+
   private func resolveUpdateMode(configured: String?) -> UpdateMode {
     let raw = configured?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
     switch raw {
@@ -316,6 +361,10 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         let latest = try await fetchLatest(channel: targetChannel)
         if let latest {
           if isCurrentBundleLatest(latest: latest, targetChannel: targetChannel) {
+            call.resolve()
+            return
+          }
+          if shouldSuppressLatestManifest(latest: latest, targetChannel: targetChannel) {
             call.resolve()
             return
           }
@@ -437,7 +486,7 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     emitEvents: Bool
   ) async throws -> BundleInfo? {
     let targetChannel = resolveTargetChannel(channel)
-    var latest = try await fetchLatest(channel: targetChannel)
+    let latest = try await fetchLatest(channel: targetChannel)
 
     guard var manifest = latest else {
       if emitEvents {
@@ -461,6 +510,13 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
       return nil
     }
 
+    if shouldSuppressLatestManifest(latest: manifest, targetChannel: targetChannel) {
+      if emitEvents {
+        notifyListeners("noUpdateAvailable", data: [:])
+      }
+      return nil
+    }
+
     let staged = findMatchingStagedBundle(latest: manifest, targetChannel: targetChannel)
     if emitEvents {
       notifyListeners("updateAvailable", data: manifestToDictionary(manifest, downloaded: staged != nil))
@@ -470,45 +526,7 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
       return staged
     }
 
-    guard var url = URL(string: manifest.url) else {
-      throw NSError(
-        domain: "OtaKit",
-        code: 1,
-        userInfo: [NSLocalizedDescriptionKey: "Invalid download URL from manifest"]
-      )
-    }
-
-    do {
-      return try await downloadAndStage(
-        url: url,
-        version: manifest.version,
-        expectedSha256: manifest.sha256,
-        expectedSize: manifest.size,
-        runtimeVersion: manifest.runtimeVersion,
-        channel: targetChannel,
-        releaseId: manifest.releaseId
-      )
-    } catch let error as NSError where isExpiredURLError(error) {
-      // Download URL may have expired — re-fetch manifest once and retry
-      latest = try await fetchLatest(channel: targetChannel)
-      guard let refreshed = latest else {
-        throw error
-      }
-      manifest = refreshed
-      guard let retryUrl = URL(string: manifest.url) else {
-        throw error
-      }
-      url = retryUrl
-      return try await downloadAndStage(
-        url: url,
-        version: manifest.version,
-        expectedSha256: manifest.sha256,
-        expectedSize: manifest.size,
-        runtimeVersion: manifest.runtimeVersion,
-        channel: targetChannel,
-        releaseId: manifest.releaseId
-      )
-    }
+    return try await downloadLatestManifest(manifest, targetChannel: targetChannel)
   }
 
   private func isExpiredURLError(_ error: NSError) -> Bool {
@@ -670,6 +688,7 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
       return store.getCurrentBundle()
     }
 
+    resolveCurrentRuntimeKey()
     store.setCurrentBundleId(staged.id)
     store.setStagedBundleId(nil)
     return staged
@@ -688,6 +707,7 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
       return
     }
 
+    resolveCurrentRuntimeKey()
     store.setCurrentBundleId(staged.id)
     store.setStagedBundleId(nil)
 
@@ -867,6 +887,44 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     doesBundleMatchLatest(store.getCurrentBundle(), latest: latest, targetChannel: targetChannel)
   }
 
+  private func shouldSuppressLatestManifest(
+    latest: LatestManifest,
+    targetChannel: String?
+  ) -> Bool {
+    guard let failed = store.getFailedBundle() else {
+      return false
+    }
+    return doesFailedBundleMatchLatest(failed, latest: latest, targetChannel: targetChannel)
+  }
+
+  private func doesFailedBundleMatchLatest(
+    _ failed: BundleInfo,
+    latest: LatestManifest,
+    targetChannel: String?
+  ) -> Bool {
+    if trimToNil(failed.channel) != targetChannel {
+      return false
+    }
+
+    if trimToNil(failed.runtimeVersion) != trimToNil(latest.runtimeVersion) {
+      return false
+    }
+
+    if let failedReleaseId = failed.releaseId,
+       latest.releaseId == failedReleaseId {
+      return true
+    }
+
+    if !latest.sha256.isEmpty,
+       let failedSha = failed.sha256,
+       !failedSha.isEmpty,
+       latest.sha256 == failedSha {
+      return true
+    }
+
+    return false
+  }
+
   private func doesBundleMatchLatest(
     _ bundle: BundleInfo,
     latest: LatestManifest,
@@ -916,6 +974,47 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     return doesBundleMatchLatest(staged, latest: latest, targetChannel: targetChannel) ? staged : nil
+  }
+
+  private func downloadLatestManifest(
+    _ manifest: LatestManifest,
+    targetChannel: String?
+  ) async throws -> BundleInfo {
+    guard let url = URL(string: manifest.url) else {
+      throw NSError(
+        domain: "OtaKit",
+        code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Invalid download URL from manifest"]
+      )
+    }
+
+    do {
+      return try await downloadAndStage(
+        url: url,
+        version: manifest.version,
+        expectedSha256: manifest.sha256,
+        expectedSize: manifest.size,
+        runtimeVersion: manifest.runtimeVersion,
+        channel: targetChannel,
+        releaseId: manifest.releaseId
+      )
+    } catch let error as NSError where isExpiredURLError(error) {
+      guard let refreshed = try await fetchLatest(channel: targetChannel) else {
+        throw error
+      }
+      guard let retryURL = URL(string: refreshed.url) else {
+        throw error
+      }
+      return try await downloadAndStage(
+        url: retryURL,
+        version: refreshed.version,
+        expectedSha256: refreshed.sha256,
+        expectedSize: refreshed.size,
+        runtimeVersion: refreshed.runtimeVersion,
+        channel: targetChannel,
+        releaseId: refreshed.releaseId
+      )
+    }
   }
 
   private func pruneIncompatibleBundles() {

--- a/packages/capacitor-plugin/src/definitions.ts
+++ b/packages/capacitor-plugin/src/definitions.ts
@@ -79,6 +79,12 @@ export interface OtaKitConfig {
   /** Overall update behavior. Defaults to next-launch. */
   updateMode?: OtaKitUpdateMode;
   /**
+   * On fresh install or after a runtimeVersion change, bypass the normal launch flow once:
+   * check live, download if needed, and apply immediately on cold start.
+   * Only affects automatic `next-launch` / `next-resume` mode. Ignored in `manual` and `immediate`.
+   */
+  immediateUpdateOnRuntimeChange?: boolean;
+  /**
    * Minimum milliseconds between automatic update checks.
    * Applies only to automatic checks in `next-launch` and `next-resume`.
    * Manual APIs and `immediate` mode bypass this throttle. Defaults to 600000 (10 min).

--- a/packages/site/app/docs/plugin/page.tsx
+++ b/packages/site/app/docs/plugin/page.tsx
@@ -2,8 +2,7 @@ import { Separator } from '@/components/ui/separator';
 
 export const metadata = {
   title: 'Plugin API — OtaKit Docs',
-  description:
-    'Capacitor plugin setup, default automatic updates, and manual advanced flows.',
+  description: 'Capacitor plugin setup, default automatic updates, and manual advanced flows.',
 };
 
 export default function PluginReferencePage() {
@@ -11,9 +10,9 @@ export default function PluginReferencePage() {
     <>
       <h1 className="text-2xl font-bold tracking-tight">Plugin API</h1>
       <P>
-        Import from <Code>@otakit/capacitor-updater</Code>. The normal flow usually only 
-        needs <Code>notifyAppReady()</Code>. The other public methods exist for advanced manual 
-        update flows where your app decides when to check, download, and apply an update.
+        Import from <Code>@otakit/capacitor-updater</Code>. The normal flow usually only needs{' '}
+        <Code>notifyAppReady()</Code>. The other public methods exist for advanced manual update
+        flows where your app decides when to check, download, and apply an update.
       </P>
       <Pre>{`import { OtaKit } from "@otakit/capacitor-updater";`}</Pre>
 
@@ -29,6 +28,7 @@ export default function PluginReferencePage() {
     // channel: "production",
     // runtimeVersion: "2026.04",
     // updateMode: "next-resume",
+    // immediateUpdateOnRuntimeChange: true,
   }
 }`}</Pre>
       <div className="mt-4 overflow-x-auto rounded-lg border text-xs">
@@ -51,6 +51,11 @@ export default function PluginReferencePage() {
           field="updateMode"
           type="'manual' | 'next-launch' | 'next-resume' | 'immediate'"
           description="Overall update behavior. Optional, defaults to next-launch."
+        />
+        <ConfigRow
+          field="immediateUpdateOnRuntimeChange"
+          type="boolean"
+          description="One-time cold-start override for fresh installs or runtimeVersion changes. In next-launch/next-resume, it checks live, bypasses checkInterval, and applies immediately if needed."
         />
         <ConfigRow
           field="checkInterval"
@@ -106,14 +111,25 @@ export default function PluginReferencePage() {
         The CLI reads that same value automatically during upload, so releases stay simple: release
         the bundle and it naturally stays inside its own runtime lane.
       </P>
+      <P>
+        If you want fresh installs or new native shells to catch up on first launch, enable{' '}
+        <Code>immediateUpdateOnRuntimeChange</Code>. That override is launch-only: it bypasses{' '}
+        <Code>checkInterval</Code>, performs a live check for the current runtime lane, and then
+        returns to the normal update mode after the lane is resolved.
+      </P>
 
       <Separator className="my-10" />
 
       <H2>Update Modes</H2>
       <P>
-        <Code>next-launch</Code> and <Code>next-resume</Code> check on cold start and app
-        resume, throttled by <Code>checkInterval</Code>. <Code>immediate</Code> ignores the
-        interval, and manual APIs always perform a live check.
+        <Code>next-launch</Code> and <Code>next-resume</Code> check on cold start and app resume,
+        throttled by <Code>checkInterval</Code>. <Code>immediate</Code> ignores the interval, and
+        manual APIs always perform a live check.
+      </P>
+      <P>
+        <Code>immediateUpdateOnRuntimeChange</Code> only augments automatic <Code>next-launch</Code>{' '}
+        and <Code>next-resume</Code>. It is ignored in <Code>manual</Code> and redundant in{' '}
+        <Code>immediate</Code>.
       </P>
       <div className="mt-4 overflow-x-auto rounded-lg border text-xs">
         <ConfigRow


### PR DESCRIPTION
Fresh installs and runtimeVersion lane changes now get an immediate catch-up on cold start when this flag is enabled, without switching the whole app to updateMode: "immediate".