### PR TITLE
feat: manifest canonical payload v2 (strategy, forceImmediate, encryption)

### DIFF
--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/ManifestClient.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/ManifestClient.java
@@ -28,6 +28,23 @@ final class ManifestClient {
     }
   }
 
+  static final class ManifestEncryption {
+
+    final String alg;
+    final String kid;
+    final String wrapNonce;
+    final String wrappedDek;
+    final String nonce;
+
+    ManifestEncryption(String alg, String kid, String wrapNonce, String wrappedDek, String nonce) {
+      this.alg = alg;
+      this.kid = kid;
+      this.wrapNonce = wrapNonce;
+      this.wrappedDek = wrappedDek;
+      this.nonce = nonce;
+    }
+  }
+
   static final class LatestManifest {
 
     final String version;
@@ -36,6 +53,9 @@ final class ManifestClient {
     final int size;
     final String runtimeVersion;
     final String releaseId;
+    final String strategy;
+    final boolean forceImmediate;
+    final ManifestEncryption encryption;
 
     LatestManifest(
       String version,
@@ -43,7 +63,10 @@ final class ManifestClient {
       String sha256,
       int size,
       String runtimeVersion,
-      String releaseId
+      String releaseId,
+      String strategy,
+      boolean forceImmediate,
+      ManifestEncryption encryption
     ) {
       this.version = version;
       this.url = url;
@@ -51,6 +74,9 @@ final class ManifestClient {
       this.size = size;
       this.runtimeVersion = runtimeVersion;
       this.releaseId = releaseId;
+      this.strategy = strategy;
+      this.forceImmediate = forceImmediate;
+      this.encryption = encryption;
     }
   }
 
@@ -145,6 +171,16 @@ final class ManifestClient {
         throw new IllegalStateException("Manifest response missing required releaseId");
       }
 
+      String strategy = "zip";
+      if (json.has("strategy") && !json.isNull("strategy")) {
+        String rawStrategy = json.getString("strategy").trim();
+        if (!rawStrategy.isEmpty()) {
+          strategy = rawStrategy;
+        }
+      }
+      boolean forceImmediate = json.optBoolean("forceImmediate", false);
+      ManifestEncryption encryption = parseEncryption(json);
+
       requireHTTPS(new URL(downloadUrl), allowInsecureUrls);
 
       if (manifestKeys == null || manifestKeys.isEmpty()) {
@@ -168,6 +204,9 @@ final class ManifestClient {
           sha256,
           size,
           responseRuntimeVersion,
+          strategy,
+          forceImmediate,
+          encryption,
           signature,
           manifestKeys
         );
@@ -179,11 +218,37 @@ final class ManifestClient {
         sha256,
         size,
         responseRuntimeVersion,
-        releaseId
+        releaseId,
+        strategy,
+        forceImmediate,
+        encryption
       );
     } finally {
       connection.disconnect();
     }
+  }
+
+  private static ManifestEncryption parseEncryption(JSONObject json) throws Exception {
+    if (!json.has("encryption") || json.isNull("encryption")) {
+      return null;
+    }
+    JSONObject encObj = json.getJSONObject("encryption");
+    if (
+      !encObj.has("alg") ||
+      !encObj.has("kid") ||
+      !encObj.has("wrapNonce") ||
+      !encObj.has("wrappedDek") ||
+      !encObj.has("nonce")
+    ) {
+      throw new IllegalStateException("Manifest encryption block is missing required fields");
+    }
+    return new ManifestEncryption(
+      encObj.getString("alg"),
+      encObj.getString("kid"),
+      encObj.getString("wrapNonce"),
+      encObj.getString("wrappedDek"),
+      encObj.getString("nonce")
+    );
   }
 
   private static String readStream(InputStream input) throws Exception {

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/ManifestClient.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/ManifestClient.java
@@ -178,7 +178,9 @@ final class ManifestClient {
           strategy = rawStrategy;
         }
       }
-      boolean forceImmediate = json.optBoolean("forceImmediate", false);
+      // Strict boolean (no string coercion) to match the iOS parser.
+      Object rawForceImmediate = json.opt("forceImmediate");
+      boolean forceImmediate = Boolean.TRUE.equals(rawForceImmediate);
       ManifestEncryption encryption = parseEncryption(json);
 
       requireHTTPS(new URL(downloadUrl), allowInsecureUrls);

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/ManifestVerifier.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/ManifestVerifier.java
@@ -34,6 +34,9 @@ final class ManifestVerifier {
     String sha256,
     int size,
     String runtimeVersion,
+    String strategy,
+    boolean forceImmediate,
+    ManifestClient.ManifestEncryption encryption,
     ManifestClient.ManifestSignature signature,
     List<KeyEntry> trustedKeys
   ) throws Exception {
@@ -44,6 +47,9 @@ final class ManifestVerifier {
       sha256,
       size,
       runtimeVersion,
+      strategy,
+      forceImmediate,
+      encryption,
       signature.kid,
       signature.iat,
       signature.exp
@@ -91,6 +97,31 @@ final class ManifestVerifier {
     }
   }
 
+  /**
+   * Encode the encryption block for the canonical payload.
+   * Must match the server's encodeEncryptionForPayload exactly.
+   */
+  private static String encodeEncryptionForPayload(ManifestClient.ManifestEncryption encryption) {
+    if (encryption == null) {
+      return "null";
+    }
+    return (
+      encryption.alg +
+      "|" +
+      encryption.kid +
+      "|" +
+      encryption.wrapNonce +
+      "|" +
+      encryption.wrappedDek +
+      "|" +
+      encryption.nonce
+    );
+  }
+
+  /**
+   * Canonical payload v2 — must match the server's buildCanonicalPayload
+   * (console/lib/manifest-signing.ts) and the iOS mirror byte-for-byte.
+   */
   private static String buildCanonicalPayload(
     String appId,
     String channel,
@@ -98,6 +129,9 @@ final class ManifestVerifier {
     String sha256,
     int size,
     String runtimeVersion,
+    String strategy,
+    boolean forceImmediate,
+    ManifestClient.ManifestEncryption encryption,
     String kid,
     int iat,
     int exp
@@ -121,6 +155,15 @@ final class ManifestVerifier {
       "\n" +
       "runtimeVersion:" +
       (runtimeVersion != null ? runtimeVersion : "null") +
+      "\n" +
+      "strategy:" +
+      strategy +
+      "\n" +
+      "forceImmediate:" +
+      (forceImmediate ? "true" : "false") +
+      "\n" +
+      "encryption:" +
+      encodeEncryptionForPayload(encryption) +
       "\n" +
       "kid:" +
       kid +

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/ManifestClient.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/ManifestClient.swift
@@ -3,6 +3,14 @@ import Foundation
 private let baseChannelKey = "__base__"
 private let defaultRuntimeKey = "__default__"
 
+struct ManifestEncryption {
+  let alg: String
+  let kid: String
+  let wrapNonce: String
+  let wrappedDek: String
+  let nonce: String
+}
+
 struct LatestManifest {
   let version: String
   let url: String
@@ -10,6 +18,9 @@ struct LatestManifest {
   let size: Int
   let runtimeVersion: String?
   let releaseId: String
+  let strategy: String
+  let forceImmediate: Bool
+  let encryption: ManifestEncryption?
 }
 
 struct ManifestSignature {
@@ -112,6 +123,12 @@ enum ManifestClient {
       throw ManifestClientError.invalidResponse
     }
 
+    let strategy = (object["strategy"] as? String)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .nilIfEmpty ?? "zip"
+    let forceImmediate = object["forceImmediate"] as? Bool ?? false
+    let encryption = try parseEncryption(object["encryption"])
+
     guard let dlURL = URL(string: downloadUrl) else {
       throw ManifestClientError.invalidURL
     }
@@ -133,6 +150,9 @@ enum ManifestClient {
         sha256: sha256,
         size: size,
         runtimeVersion: runtimeVersion,
+        strategy: strategy,
+        forceImmediate: forceImmediate,
+        encryption: encryption,
         signature: signature,
         trustedKeys: manifestKeys
       )
@@ -144,7 +164,31 @@ enum ManifestClient {
       sha256: sha256,
       size: size,
       runtimeVersion: runtimeVersion,
-      releaseId: releaseId
+      releaseId: releaseId,
+      strategy: strategy,
+      forceImmediate: forceImmediate,
+      encryption: encryption
+    )
+  }
+
+  private static func parseEncryption(_ rawValue: Any?) throws -> ManifestEncryption? {
+    guard let rawValue, !(rawValue is NSNull) else {
+      return nil
+    }
+    guard let object = rawValue as? [String: Any],
+          let alg = object["alg"] as? String,
+          let kid = object["kid"] as? String,
+          let wrapNonce = object["wrapNonce"] as? String,
+          let wrappedDek = object["wrappedDek"] as? String,
+          let nonce = object["nonce"] as? String else {
+      throw ManifestClientError.invalidResponse
+    }
+    return ManifestEncryption(
+      alg: alg,
+      kid: kid,
+      wrapNonce: wrapNonce,
+      wrappedDek: wrappedDek,
+      nonce: nonce
     )
   }
 

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/ManifestVerifier.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/ManifestVerifier.swift
@@ -31,6 +31,9 @@ enum ManifestVerifier {
     sha256: String,
     size: Int,
     runtimeVersion: String?,
+    strategy: String,
+    forceImmediate: Bool,
+    encryption: ManifestEncryption?,
     signature: ManifestSignature,
     trustedKeys: [ManifestKey]
   ) throws {
@@ -41,6 +44,9 @@ enum ManifestVerifier {
       sha256: sha256,
       size: size,
       runtimeVersion: runtimeVersion,
+      strategy: strategy,
+      forceImmediate: forceImmediate,
+      encryption: encryption,
       kid: signature.kid,
       iat: signature.iat,
       exp: signature.exp
@@ -78,6 +84,23 @@ enum ManifestVerifier {
     }
   }
 
+  /// Encode the encryption block for the canonical payload.
+  /// Must match the server's `encodeEncryptionForPayload` exactly.
+  private static func encodeEncryptionForPayload(_ encryption: ManifestEncryption?) -> String {
+    guard let encryption else {
+      return "null"
+    }
+    return [
+      encryption.alg,
+      encryption.kid,
+      encryption.wrapNonce,
+      encryption.wrappedDek,
+      encryption.nonce,
+    ].joined(separator: "|")
+  }
+
+  /// Canonical payload v2 — must match the server's `buildCanonicalPayload`
+  /// (console/lib/manifest-signing.ts) and the Android mirror byte-for-byte.
   private static func buildCanonicalPayload(
     appId: String,
     channel: String?,
@@ -85,6 +108,9 @@ enum ManifestVerifier {
     sha256: String,
     size: Int,
     runtimeVersion: String?,
+    strategy: String,
+    forceImmediate: Bool,
+    encryption: ManifestEncryption?,
     kid: String,
     iat: Int,
     exp: Int
@@ -97,6 +123,9 @@ enum ManifestVerifier {
       "sha256:\(sha256)",
       "size:\(size)",
       "runtimeVersion:\(runtimeVersion ?? "null")",
+      "strategy:\(strategy)",
+      "forceImmediate:\(forceImmediate ? "true" : "false")",
+      "encryption:\(encodeEncryptionForPayload(encryption))",
       "kid:\(kid)",
       "iat:\(iat)",
       "exp:\(exp)",

--- a/packages/console/lib/manifest-files.ts
+++ b/packages/console/lib/manifest-files.ts
@@ -64,6 +64,9 @@ export async function writeManifestFile(
     sha256: bundle.sha256,
     size: bundle.size,
     runtimeVersion: bundle.runtimeVersion,
+    strategy: 'zip',
+    forceImmediate: false,
+    encryption: null,
   });
 
   await putTextObject({
@@ -76,6 +79,8 @@ export async function writeManifestFile(
       channel,
       runtimeVersion: bundle.runtimeVersion,
       releaseId: release.id,
+      strategy: 'zip',
+      forceImmediate: false,
       signature,
     }),
     contentType: 'application/json; charset=utf-8',

--- a/packages/console/lib/manifest-signing.ts
+++ b/packages/console/lib/manifest-signing.ts
@@ -3,6 +3,16 @@ import crypto from 'node:crypto';
 const MANIFEST_PAYLOAD_HEADER = 'MANIFEST';
 const DEFAULT_MANIFEST_TTL_SECONDS = 31_536_000; // 1 year
 
+export type ManifestStrategy = 'zip' | 'deltas';
+
+export interface ManifestEncryptionInput {
+  alg: string;
+  kid: string;
+  wrapNonce: string;
+  wrappedDek: string;
+  nonce: string;
+}
+
 export interface ManifestSignatureInput {
   appId: string;
   channel: string | null;
@@ -10,6 +20,12 @@ export interface ManifestSignatureInput {
   sha256: string;
   size: number;
   runtimeVersion: string | null;
+  /** Update strategy baked into the manifest. Defaults to 'zip'. */
+  strategy?: ManifestStrategy;
+  /** Per-release emergency escalation flag. Defaults to false. */
+  forceImmediate?: boolean;
+  /** Bundle encryption parameters, or null when the bundle is not encrypted. */
+  encryption?: ManifestEncryptionInput | null;
 }
 
 export interface ManifestSignature {
@@ -51,10 +67,38 @@ function getSigningKey(): { privateKey: crypto.KeyObject; kid: string } | null {
 }
 
 /**
- * Build the deterministic canonical payload string.
+ * Encode the encryption block for the canonical payload.
+ *
+ * "null" when the bundle is not encrypted; otherwise a fixed-order
+ * pipe-joined string covering every encryption parameter, so tampering any
+ * of them invalidates the signature.
+ */
+function encodeEncryptionForPayload(
+  encryption: ManifestEncryptionInput | null | undefined,
+): string {
+  if (!encryption) {
+    return 'null';
+  }
+  return [
+    encryption.alg,
+    encryption.kid,
+    encryption.wrapNonce,
+    encryption.wrappedDek,
+    encryption.nonce,
+  ].join('|');
+}
+
+/**
+ * Build the deterministic canonical payload string (payload v2).
  *
  * Format: fixed field order, newline-separated, explicit "null" for missing values.
- * Both server and native plugins must produce the identical string.
+ * Both server and native plugins must produce the identical string
+ * (see ManifestVerifier.swift / ManifestVerifier.java).
+ *
+ * v2 adds `strategy`, `forceImmediate`, and `encryption` between
+ * `runtimeVersion` and `kid`. All three are always present with explicit
+ * defaults (`zip` / `false` / `null`) so future features populate existing
+ * fields instead of changing the format again.
  */
 export function buildCanonicalPayload(
   fields: ManifestSignatureInput,
@@ -70,6 +114,9 @@ export function buildCanonicalPayload(
     `sha256:${fields.sha256}`,
     `size:${fields.size}`,
     `runtimeVersion:${fields.runtimeVersion ?? 'null'}`,
+    `strategy:${fields.strategy ?? 'zip'}`,
+    `forceImmediate:${fields.forceImmediate ? 'true' : 'false'}`,
+    `encryption:${encodeEncryptionForPayload(fields.encryption)}`,
     `kid:${kid}`,
     `iat:${iat}`,
     `exp:${exp}`,


### PR DESCRIPTION
## What

Extends the signed manifest canonical payload **once** with all three planned fields, so the upcoming features populate existing fields instead of each breaking the signature format:

- `strategy:zip` (delta updates, plan 01)
- `forceImmediate:false` (emergency flag, plan 06)
- `encryption:null` (bundle encryption, plan 02; pipe-joined param block when present)

Inserted between `runtimeVersion` and `kid`, always present with explicit defaults. The manifest JSON also now carries `strategy` + `forceImmediate`.

## Where

- `console/lib/manifest-signing.ts` — signer + input types
- `console/lib/manifest-files.ts` — bake defaults into manifest JSON + sign call
- iOS `ManifestClient.swift` / `ManifestVerifier.swift` — parse (tolerant defaults) + rebuild identical v2 string
- Android `ManifestClient.java` / `ManifestVerifier.java` — mirrors

## Why now

Changing the canonical string breaks verification for already-shipped plugin builds. With no production users this is a free, clean break; after launch it would require key rotation / dual signing. Plans 01/02/06 stack on this branch.

## Verification

- `pnpm --filter @otakit/console typecheck` ✅
- `xcrun swiftc -parse` on both edited Swift files ✅
- prettier (TS + Java via prettier-plugin-java) ✅
- Cross-impl vector (all three builders produce):
  ```
  MANIFEST\nappId:app-1\nchannel:null\nversion:1.2.3\nsha256:abc\nsize:42\nruntimeVersion:null\nstrategy:zip\nforceImmediate:false\nencryption:null\nkid:k1\niat:100\nexp:200
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)