### PR TITLE
feat(plugin): setChannel/getChannel runtime channel override

### DIFF
--- a/packages/capacitor-plugin/README.md
+++ b/packages/capacitor-plugin/README.md
@@ -238,6 +238,42 @@ After the app reloads and starts again, call:
 await OtaKit.notifyAppReady();
 ```
 
+## Runtime channel switching
+
+`setChannel()` overrides the configured channel at runtime — for example a
+"Join beta" toggle in settings — without rebuilding the app:
+
+```ts
+// Opt into the beta channel; takes effect on the next check/download cycle.
+await OtaKit.setChannel({ channel: 'beta' });
+
+// Back to the channel from capacitor.config.ts (or the base channel).
+await OtaKit.setChannel({ channel: null });
+
+const { channel, source } = await OtaKit.getChannel();
+// source is 'override' after setChannel(), 'config' otherwise
+```
+
+The override is persisted across launches and slots into channel resolution
+as: explicit call argument → persisted override → config `channel` → base.
+`setChannel()` itself never checks, downloads, or reloads anything — call
+`OtaKit.download()` / `OtaKit.update()` afterwards if you want the switch to
+take effect immediately.
+
+Channel names must match `^[A-Za-z0-9._-]{1,64}$`, must not contain `..`, and
+must not be the reserved names `base` or `default` (matching server-side
+validation). Invalid names reject without persisting.
+
+Limitations to be aware of:
+
+- **Channels are public CDN paths.** A channel name is not a secret and this
+  cannot enforce private distribution — anyone who guesses the name can fetch
+  that channel's manifest.
+- **The backend is not aware of the switch.** There is no server-side record
+  of which device is on which channel; the switch is purely client-side.
+- **The channel must exist and have a release.** Switching to a channel with
+  no published manifest yields `no_update` until something is released there.
+
 ## Compatibility lanes
 
 - `channel` answers "who should get this rollout?"

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/BundleStore.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/BundleStore.java
@@ -22,6 +22,7 @@ final class BundleStore {
   private static final String KEY_STAGED = "staged_bundle_id";
   private static final String KEY_LAST_FAILED_BUNDLE_INFO = "last_failed_bundle_info";
   private static final String KEY_LAST_RESOLVED_RUNTIME_KEY = "last_resolved_runtime_key";
+  private static final String KEY_OVERRIDE_CHANNEL = "override_channel";
 
   private final Context context;
   private final SharedPreferences prefs;
@@ -215,6 +216,20 @@ final class BundleStore {
     } catch (Exception e) {
       return null;
     }
+  }
+
+  synchronized String getOverrideChannel() {
+    return prefs.getString(KEY_OVERRIDE_CHANNEL, null);
+  }
+
+  synchronized void setOverrideChannel(String channel) {
+    SharedPreferences.Editor editor = prefs.edit();
+    if (channel == null) {
+      editor.remove(KEY_OVERRIDE_CHANNEL);
+    } else {
+      editor.putString(KEY_OVERRIDE_CHANNEL, channel);
+    }
+    editor.commit();
   }
 
   synchronized String getLastResolvedRuntimeKey() {

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
@@ -115,6 +115,8 @@ public class UpdaterPlugin extends Plugin {
   private static final String KEY_LAST_CHECK_TIMESTAMP = "last_check_timestamp";
   private static final String DEFAULT_RUNTIME_KEY = "__default__";
   private static final String BUILTIN_ASSET_PATH = "public";
+  private static final java.util.regex.Pattern CHANNEL_NAME_PATTERN =
+    java.util.regex.Pattern.compile("^[A-Za-z0-9._-]{1,64}$");
   private UpdaterCoordinator.StartupPreparation pendingStartupPreparation;
 
   @Override
@@ -524,6 +526,63 @@ public class UpdaterPlugin extends Plugin {
       return;
     }
     call.resolve(failed.toJSObject());
+  }
+
+  @PluginMethod
+  public void setChannel(PluginCall call) {
+    Object raw = call.getData().opt("channel");
+    if (raw == null || raw == org.json.JSONObject.NULL) {
+      store.setOverrideChannel(null);
+      call.resolve();
+      return;
+    }
+    if (!(raw instanceof String)) {
+      call.reject("channel must be a string or null");
+      return;
+    }
+    String name = (String) raw;
+    if (!isValidChannelName(name)) {
+      call.reject(
+        "Invalid channel name '" +
+          name +
+          "': use 1-64 letters, numbers, '.', '_' or '-' (reserved names: base, default)"
+      );
+      return;
+    }
+    store.setOverrideChannel(name);
+    call.resolve();
+  }
+
+  @PluginMethod
+  public void getChannel(PluginCall call) {
+    JSObject result = new JSObject();
+    String override = store.getOverrideChannel();
+    if (override != null) {
+      result.put("channel", override);
+      result.put("source", "override");
+      call.resolve(result);
+      return;
+    }
+    result.put("channel", channel != null ? channel : org.json.JSONObject.NULL);
+    result.put("source", "config");
+    call.resolve(result);
+  }
+
+  /**
+   * Mirrors the server's isValidChannelName (console/lib/validation.ts):
+   * charset regex plus reserved names. The channel is interpolated into the
+   * manifest CDN path, so anything outside this charset (or a ".." sequence)
+   * is rejected before it is persisted or used.
+   */
+  private boolean isValidChannelName(String name) {
+    if (!CHANNEL_NAME_PATTERN.matcher(name).matches()) {
+      return false;
+    }
+    if (name.contains("..")) {
+      return false;
+    }
+    String lower = name.toLowerCase(java.util.Locale.ROOT);
+    return !"base".equals(lower) && !"default".equals(lower);
   }
 
   private ManifestClient.LatestManifest fetchLatest(String channel) throws Exception {
@@ -1092,7 +1151,14 @@ public class UpdaterPlugin extends Plugin {
 
   private String resolveTargetChannel(String channel) {
     String resolved = trimToNull(channel);
-    return resolved != null ? resolved : this.channel;
+    if (resolved != null) {
+      return resolved;
+    }
+    String override = store.getOverrideChannel();
+    if (override != null) {
+      return override;
+    }
+    return this.channel;
   }
 
   private void sendDeviceEvent(

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
@@ -578,7 +578,7 @@ public class UpdaterPlugin extends Plugin {
     if (!CHANNEL_NAME_PATTERN.matcher(name).matches()) {
       return false;
     }
-    if (name.contains("..")) {
+    if (name.contains("..") || ".".equals(name)) {
       return false;
     }
     String lower = name.toLowerCase(java.util.Locale.ROOT);

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/BundleStore.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/BundleStore.swift
@@ -7,6 +7,7 @@ final class BundleStore {
     static let stagedBundleId = "otakit_staged_bundle_id"
     static let lastFailedBundleInfo = "otakit_last_failed_bundle_info"
     static let lastResolvedRuntimeKey = "otakit_last_resolved_runtime_key"
+    static let overrideChannel = "otakit_override_channel"
   }
 
   private let defaults = UserDefaults.standard
@@ -204,6 +205,18 @@ final class BundleStore {
       return nil
     }
     return try? decoder.decode(BundleInfo.self, from: data)
+  }
+
+  func getOverrideChannel() -> String? {
+    defaults.string(forKey: Keys.overrideChannel)
+  }
+
+  func setOverrideChannel(_ channel: String?) {
+    if let channel {
+      defaults.set(channel, forKey: Keys.overrideChannel)
+    } else {
+      defaults.removeObject(forKey: Keys.overrideChannel)
+    }
   }
 
   func getLastResolvedRuntimeKey() -> String? {

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
@@ -465,10 +465,12 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
   /// manifest CDN path, so anything outside this charset (or a ".." sequence)
   /// is rejected before it is persisted or used.
   private func isValidChannelName(_ name: String) -> Bool {
-    guard name.range(of: "^[A-Za-z0-9._-]{1,64}$", options: .regularExpression) != nil else {
+    // \A/\z anchor the whole input: ICU's ^/$ would accept a trailing
+    // line terminator (e.g. "beta\n"), diverging from Android/server.
+    guard name.range(of: "\\A[A-Za-z0-9._-]{1,64}\\z", options: .regularExpression) != nil else {
       return false
     }
-    if name.contains("..") {
+    if name.contains("..") || name == "." {
       return false
     }
     return !["base", "default"].contains(name.lowercased())

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
@@ -33,6 +33,8 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     CAPPluginMethod(name: "update", returnType: CAPPluginReturnPromise),
     CAPPluginMethod(name: "notifyAppReady", returnType: CAPPluginReturnPromise),
     CAPPluginMethod(name: "getLastFailure", returnType: CAPPluginReturnPromise),
+    CAPPluginMethod(name: "setChannel", returnType: CAPPluginReturnPromise),
+    CAPPluginMethod(name: "getChannel", returnType: CAPPluginReturnPromise),
   ]
 
   private let store = BundleStore()
@@ -424,6 +426,52 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
       return
     }
     call.resolve(failed.toDictionary())
+  }
+
+  @objc func setChannel(_ call: CAPPluginCall) {
+    let raw = call.options["channel"]
+    if raw == nil || raw is NSNull {
+      store.setOverrideChannel(nil)
+      call.resolve()
+      return
+    }
+    guard let name = raw as? String else {
+      call.reject("channel must be a string or null")
+      return
+    }
+    guard isValidChannelName(name) else {
+      call.reject(
+        "Invalid channel name '\(name)': use 1-64 letters, numbers, '.', '_' or '-' (reserved names: base, default)"
+      )
+      return
+    }
+    store.setOverrideChannel(name)
+    call.resolve()
+  }
+
+  @objc func getChannel(_ call: CAPPluginCall) {
+    if let override = store.getOverrideChannel() {
+      call.resolve(["channel": override, "source": "override"])
+      return
+    }
+    call.resolve([
+      "channel": channel ?? NSNull(),
+      "source": "config",
+    ])
+  }
+
+  /// Mirrors the server's isValidChannelName (console/lib/validation.ts):
+  /// charset regex plus reserved names. The channel is interpolated into the
+  /// manifest CDN path, so anything outside this charset (or a ".." sequence)
+  /// is rejected before it is persisted or used.
+  private func isValidChannelName(_ name: String) -> Bool {
+    guard name.range(of: "^[A-Za-z0-9._-]{1,64}$", options: .regularExpression) != nil else {
+      return false
+    }
+    if name.contains("..") {
+      return false
+    }
+    return !["base", "default"].contains(name.lowercased())
   }
 
   private func fetchLatest(channel: String?) async throws -> LatestManifest? {
@@ -1020,6 +1068,9 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
   private func resolveTargetChannel(_ channel: String?) -> String? {
     if let channel = trimToNil(channel) {
       return channel
+    }
+    if let override = store.getOverrideChannel() {
+      return override
     }
     return self.channel
   }

--- a/packages/capacitor-plugin/src/definitions.ts
+++ b/packages/capacitor-plugin/src/definitions.ts
@@ -92,6 +92,13 @@ export interface DownloadStagedResult {
 
 export type DownloadResult = DownloadNoUpdateResult | DownloadStagedResult;
 
+export interface ChannelInfo {
+  /** The effective release channel, or null for the base channel. */
+  channel: string | null;
+  /** Where the effective channel comes from: a runtime override or static config. */
+  source: 'override' | 'config';
+}
+
 /**
  * Plugin configuration for capacitor.config.ts.
  */
@@ -176,6 +183,22 @@ export interface OtaKitPlugin {
    * Returns null if no failure has occurred.
    */
   getLastFailure(): Promise<BundleInfo | null>;
+
+  /**
+   * Override the release channel at runtime (e.g. a "Join beta" toggle).
+   * Pass null to clear the override and return to the configured channel.
+   *
+   * The override is persisted across launches and takes effect on the next
+   * check/download/automatic cycle — it does not trigger anything by itself.
+   * Rejects invalid channel names without persisting.
+   */
+  setChannel(options: { channel: string | null }): Promise<void>;
+
+  /**
+   * Get the effective release channel and where it comes from
+   * (a runtime override or the static plugin config).
+   */
+  getChannel(): Promise<ChannelInfo>;
 }
 
 export interface OtaKitBridgePlugin {
@@ -186,4 +209,6 @@ export interface OtaKitBridgePlugin {
   update(): Promise<void>;
   notifyAppReady(): Promise<void>;
   getLastFailure(): Promise<BundleInfo | null>;
+  setChannel(options: { channel: string | null }): Promise<void>;
+  getChannel(): Promise<ChannelInfo>;
 }

--- a/packages/capacitor-plugin/src/index.ts
+++ b/packages/capacitor-plugin/src/index.ts
@@ -30,6 +30,8 @@ const OtaKit: OtaKitPlugin = {
   notifyAppReady: () => NativeOtaKit.notifyAppReady(),
   getLastFailure: async (): Promise<BundleInfo | null> =>
     normalizeNullable(await NativeOtaKit.getLastFailure()),
+  setChannel: (options) => NativeOtaKit.setChannel(options),
+  getChannel: () => NativeOtaKit.getChannel(),
 };
 
 export * from './definitions';

--- a/packages/capacitor-plugin/src/web.ts
+++ b/packages/capacitor-plugin/src/web.ts
@@ -4,6 +4,7 @@ import type {
   OtaKitBridgePlugin,
   BundleInfo,
   BundleStatus,
+  ChannelInfo,
   CheckResult,
   DownloadResult,
   OtaKitState,
@@ -54,5 +55,23 @@ export class OtaKitWeb extends WebPlugin implements OtaKitBridgePlugin {
 
   async getLastFailure(): Promise<BundleInfo | null> {
     return null;
+  }
+
+  private static readonly OVERRIDE_CHANNEL_KEY = 'otakit_override_channel';
+
+  async setChannel(options: { channel: string | null }): Promise<void> {
+    if (options.channel === null) {
+      window.localStorage.removeItem(OtaKitWeb.OVERRIDE_CHANNEL_KEY);
+      return;
+    }
+    window.localStorage.setItem(OtaKitWeb.OVERRIDE_CHANNEL_KEY, options.channel);
+  }
+
+  async getChannel(): Promise<ChannelInfo> {
+    const override = window.localStorage.getItem(OtaKitWeb.OVERRIDE_CHANNEL_KEY);
+    if (override !== null) {
+      return { channel: override, source: 'override' };
+    }
+    return { channel: null, source: 'config' };
   }
 }

--- a/packages/capacitor-plugin/src/web.ts
+++ b/packages/capacitor-plugin/src/web.ts
@@ -59,10 +59,23 @@ export class OtaKitWeb extends WebPlugin implements OtaKitBridgePlugin {
 
   private static readonly OVERRIDE_CHANNEL_KEY = 'otakit_override_channel';
 
+  private static isValidChannelName(name: string): boolean {
+    if (!/^[A-Za-z0-9._-]{1,64}$/.test(name) || name.includes('..') || name === '.') {
+      return false;
+    }
+    const lower = name.toLowerCase();
+    return lower !== 'base' && lower !== 'default';
+  }
+
   async setChannel(options: { channel: string | null }): Promise<void> {
     if (options.channel === null) {
       window.localStorage.removeItem(OtaKitWeb.OVERRIDE_CHANNEL_KEY);
       return;
+    }
+    if (!OtaKitWeb.isValidChannelName(options.channel)) {
+      throw new Error(
+        `Invalid channel name '${options.channel}': use 1-64 letters, numbers, '.', '_' or '-' (reserved names: base, default)`,
+      );
     }
     window.localStorage.setItem(OtaKitWeb.OVERRIDE_CHANNEL_KEY, options.channel);
   }


### PR DESCRIPTION
## What

Implements plan 04: switch the release channel at runtime (e.g. a "Join beta" toggle in settings) without a store rebuild.

```ts
await OtaKit.setChannel({ channel: 'beta' });   // persisted override
await OtaKit.setChannel({ channel: null });     // back to config channel
const { channel, source } = await OtaKit.getChannel(); // source: 'override' | 'config'
```

**Zero backend work** — channels are static manifest paths on the CDN, so the switch only changes which already-published manifest the device fetches. The existing classification (`bundle.channel != targetChannel` → `update_available`) makes the download/apply/rollback loop work unchanged after a switch.

## How

- Resolution order: explicit call arg → **persisted override** (new) → config `channel` → base. One insertion in `resolveTargetChannel` per platform.
- iOS: `UserDefaults` key `otakit_override_channel` in `BundleStore`; new plugin methods in `pluginMethods` + impls.
- Android: `SharedPreferences` mirror (`override_channel` in `otakit_updater_state`).
- Web: `localStorage` stub.
- **Security**: channel names are interpolated into the manifest CDN path, so names are validated natively *before* persisting — `^[A-Za-z0-9._-]{1,64}$`, no `..`, reserved names `base`/`default` rejected (mirrors server `isValidChannelName`). Invalid names reject synchronously without persisting.
- README: new "Runtime channel switching" section documenting the API, resolution order, and honest limitations (public channel names, no server awareness, unpublished channel → `no_update`).

## Verification

- `pnpm --filter @otakit/capacitor-updater build` (tsc + rollup) ✅
- `xcrun swiftc -parse` on `UpdaterPlugin.swift`, `BundleStore.swift` ✅
- prettier (TS + Java) ✅
- Not run: iOS/Android app-level integration tests (no test infra in repo); E2E via `examples/demo-app` per plan §7 still to be done manually.

## Notes

- `setChannel` is a pure setter by design (plan §9): it does not trigger a check — callers use `OtaKit.download()`/`update()` for immediate effect.
- Signature verification keeps working with an override: the signed payload's `channel` is the requested channel, which is exactly what the server signed for that channel's manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)