### PR TITLE
feat(plugin): update lifecycle event listeners

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -13,6 +13,7 @@ Generated from the public docs pages in `packages/site/app/docs`.
 - React Guide: /docs/react
 - Channels: /docs/channels
 - Update Strategies: /docs/update-strategies
+- Events & Listeners: /docs/events
 - CI Automation: /docs/ci
 - Security: /docs/security
 - Self-hosting: /docs/self-host
@@ -48,6 +49,7 @@ Start with the quick setup
 - **Next.js Guide**: Go from Next.js + Capacitor to your first OTA update.
 - **Channels & Runtimes**: Rollout tracks vs runtime compatibility lanes, and when to use each.
 - **Update Strategies**: How launchPolicy, resumePolicy, and runtimePolicy combine to control when updates apply.
+- **Events & Listeners**: Subscribe to update lifecycle events: available, staged, applied, failed, rolled back.
 - **CI Automation**: Build and ship bundles from GitHub Actions.
 - **CLI Reference**: Commands, options, and release workflows.
 - **Plugin API**: Default automatic flow, manual flow, and configuration.
@@ -508,7 +510,7 @@ plugins: {
 - `notifyAppReady()` -> `void`: Still required after the updated bundle launches. Call this once when your app has fully loaded so the plugin can mark the new bundle healthy.
 - `getLastFailure()` -> `BundleInfo | null`: Returns information about the most recent failed update (rollback). Useful for diagnostics and crash reporting. Returns null if no failure has occurred.
 
-There is no listener API in the current plugin surface. If you want custom update UI, use `check()`, `getState()`, `download()`, and `apply()` directly.
+The plugin also emits lifecycle events — `updateAvailable`, `updateStaged`, `updateApplied`, `downloadFailed`, and `rollback` — via `OtaKit.addListener(...)`. See Events & Listeners for the full reference and the startup reconciliation pattern.
 
 After a successful `apply()` or an `update()` that installs a new bundle, the app reloads immediately. Call `notifyAppReady()` from the reloaded app startup, not in the same JS flow that triggered the activation.
 
@@ -1215,6 +1217,104 @@ Set `launchPolicy` and `resumePolicy` to `shadow`. Bundles stage in the backgrou
 Turn `launchPolicy`, `resumePolicy`, and `runtimePolicy` all `off`, then drive the lifecycle yourself with `check()`, `download()`, and `apply()`. Use this when your app wants to show its own update prompt or control install timing precisely — see the Manual Flow section of the Plugin API reference for the full pattern.
 
 Also see Channels & Runtime Version for how rollout audience and native compatibility lanes interact with these policies.
+
+## Events & Listeners
+
+Route: /docs/events
+
+Subscribe to update lifecycle events — update available, staged, applied, failed, rolled back.
+
+The plugin emits lifecycle events through the standard Capacitor listener API. Events complement — they don't replace — the pull APIs `check()` and `getState()`: listeners tell you the moment something happens while your app is running, and the pull APIs reconcile anything that happened while it wasn't.
+
+```txt
+import { OtaKit } from '@otakit/capacitor-updater';
+
+OtaKit.addListener('updateStaged', ({ bundle }) => {
+  // show "Update ready — restart now?" and call OtaKit.apply() on accept
+});
+```
+
+### Event reference
+- `updateAvailable` (LatestVersion): A check found a newer bundle, before any download starts. Fires on manual check() and at the start of automatic flows.
+- `updateStaged` ({ bundle: BundleInfo }): A bundle was downloaded, verified, and staged, ready to apply. Download and stage are atomic in OtaKit, so this is the single 'downloaded' event.
+- `updateApplied` ({ bundle: BundleInfo }): A newly activated bundle was confirmed healthy — fires when notifyAppReady() confirms the trial bundle, in the reloaded JS context.
+- `downloadFailed` ({ version, runtimeVersion?, releaseId?, channel?, reason }): A download, verification, or extraction failed. Non-terminal: the app keeps running its current bundle and retries on a later cycle.
+- `rollback` ({ version, runtimeVersion?, releaseId?, channel?, reason }): An applied bundle failed its health check (notifyAppReady timeout) and was reverted to the previous bundle.
+
+### Caveats
+- Events fire only while the app process is alive. Nothing is delivered for work that happened while the app was killed or before your listener attached — there is no buffering or replay.
+- Reconcile with `getState()` and `getLastFailure()` on startup. A bundle staged in a previous session shows up in `getState().staged`, and a startup rollback (the app restarted before `notifyAppReady()`) happens before any JS runs, so it can only be observed via `getLastFailure()`.
+- `apply()` destroys the old JS context. A listener registered before the restart will not see `updateApplied` — that event fires in the reloaded bundle. Attach `updateApplied` and `rollback` listeners early in app startup, not inside the restart click handler.
+- One `updateStaged`, no separate "downloaded" event. Download, hash verification, and staging are one atomic operation.
+
+The apply timeline, end to end:
+
+```txt
+updateStaged            (old context)
+  -> user taps "Restart"
+  -> OtaKit.apply()      (old JS context ends here; WebView reloads)
+  -> new bundle boots
+  -> app calls notifyAppReady()
+  -> updateApplied       (NEW context - attach this listener at startup)
+```
+
+### Use cases
+
+#### Auto-download in the background, prompt to apply
+
+Let `shadow` mode do the background checking, downloading, throttling, and deduplication for you, and only handle the prompt yourself:
+
+```txt
+// capacitor.config.ts
+plugins: {
+  OtaKit: { launchPolicy: 'shadow', resumePolicy: 'shadow' }
+}
+```
+
+```txt
+// app startup
+const state = await OtaKit.getState();
+if (state.staged) showRestartPrompt(state.staged);
+OtaKit.addListener('updateStaged', ({ bundle }) => showRestartPrompt(bundle));
+
+// in the prompt's accept handler
+await OtaKit.apply();
+```
+
+#### Prompt before downloading
+
+Gate the download itself (for users on metered connections) by pairing manual mode with `updateAvailable`:
+
+```txt
+// capacitor.config.ts: { launchPolicy: 'off', resumePolicy: 'off' }
+OtaKit.addListener('updateAvailable', async (latest) => {
+  if (await confirmDownload(latest.version)) {
+    await OtaKit.download(); // emits updateStaged when done
+  }
+});
+await OtaKit.check();
+```
+
+#### Post-update toast and failure reporting
+
+```txt
+// attach at startup, in the reloaded bundle
+OtaKit.addListener('updateApplied', ({ bundle }) => {
+  toast('Updated to ' + bundle.version);
+});
+OtaKit.addListener('downloadFailed', (e) => reportError('ota_download', e));
+OtaKit.addListener('rollback', (e) => reportError('ota_rollback', e));
+
+// startup rollbacks can't reach a listener - reconcile:
+const failure = await OtaKit.getLastFailure();
+if (failure) reportError('ota_rollback_startup', failure);
+```
+
+### Cleanup
+
+`addListener` resolves to a `PluginListenerHandle`; call `.remove()` on it when the owning UI unmounts, or `OtaKit.removeAllListeners()` to drop everything at once.
+
+Also see Update Strategies for choosing the policies these events observe, and the Plugin API reference for the full method list.
 
 ## CI Automation
 

--- a/packages/capacitor-plugin/README.md
+++ b/packages/capacitor-plugin/README.md
@@ -210,8 +210,42 @@ of splitting it into separate `download()` and `apply()` calls.
 - they do not resolve back into the old JS context
 - call `notifyAppReady()` from normal startup after the reloaded app boots
 
-There is no listener/event API in this refactor. If an app later needs a
-smaller reactive surface, that can be added intentionally.
+## Events
+
+The plugin emits lifecycle events alongside the pull APIs:
+
+```ts
+OtaKit.addListener('updateAvailable', (latest) => {}); // newer bundle found, before download
+OtaKit.addListener('updateStaged', ({ bundle }) => {}); // downloaded + verified + staged
+OtaKit.addListener('updateApplied', ({ bundle }) => {}); // new bundle confirmed healthy
+OtaKit.addListener('downloadFailed', (failure) => {}); // non-terminal download/verify error
+OtaKit.addListener('rollback', (failure) => {}); // applied bundle reverted (notify timeout)
+OtaKit.removeAllListeners();
+```
+
+Events fire only while the app process is alive — there is no buffering or
+replay. Reconcile on startup:
+
+- a bundle staged in a previous session: `getState().staged`
+- a startup rollback (app restarted before `notifyAppReady()`): it happens
+  before any JS runs, so it never reaches a listener — check
+  `getLastFailure()`
+
+`apply()` reloads the WebView and destroys the JS context, so `updateApplied`
+fires in the _reloaded_ bundle. Attach `updateApplied`/`rollback` listeners
+early in app startup, not in the restart click handler.
+
+Download and stage are atomic in this plugin — there is a single
+`updateStaged` event, not separate "downloaded" and "staged" events.
+
+The headline pattern — background download via `shadow` policies, prompt to
+restart:
+
+```ts
+const state = await OtaKit.getState();
+if (state.staged) showRestartPrompt(state.staged);
+OtaKit.addListener('updateStaged', ({ bundle }) => showRestartPrompt(bundle));
+```
 
 ## Example manual flow
 

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
@@ -512,6 +512,11 @@ public class UpdaterPlugin extends Plugin {
     coordinator.cleanupBundles(preparation.cleanupBundleIds);
     if (preparation.eventPayload != null) {
       sendDeviceEvent(preparation.eventPayload);
+      // eventPayload is non-null only on a genuine trial -> success transition,
+      // so repeat notifyAppReady() calls never double-emit.
+      JSObject appliedData = new JSObject();
+      appliedData.put("bundle", store.getCurrentBundle().toJSObject());
+      emitEvent("updateApplied", appliedData);
     }
     call.resolve();
   }
@@ -557,6 +562,10 @@ public class UpdaterPlugin extends Plugin {
     }
 
     CheckResolution resolution = classifyLatestManifest(latest, targetChannel);
+
+    if ("update_available".equals(resolution.kind) && resolution.latest != null) {
+      emitEvent("updateAvailable", manifestToJSObject(resolution.latest));
+    }
 
     if (respectInterval) {
       recordCheckTimestamp();
@@ -680,6 +689,10 @@ public class UpdaterPlugin extends Plugin {
           releaseId,
           "insufficient_disk_space"
         );
+        emitEvent(
+          "downloadFailed",
+          failureEventData(version, runtimeVersion, channel, releaseId, "insufficient_disk_space")
+        );
         throw new IllegalStateException("Insufficient disk space");
       }
     }
@@ -726,6 +739,9 @@ public class UpdaterPlugin extends Plugin {
       coordinator.cleanupBundles(cleanupBundleIds);
 
       sendDeviceEvent("downloaded", version, runtimeVersion, channel, releaseId, null);
+      JSObject stagedData = new JSObject();
+      stagedData.put("bundle", info.toJSObject());
+      emitEvent("updateStaged", stagedData);
       return info;
     } catch (Exception e) {
       sendDeviceEvent(
@@ -735,6 +751,10 @@ public class UpdaterPlugin extends Plugin {
         channel,
         releaseId,
         e.getMessage()
+      );
+      emitEvent(
+        "downloadFailed",
+        failureEventData(version, runtimeVersion, channel, releaseId, failureReason(e))
       );
       throw e;
     } finally {
@@ -856,6 +876,18 @@ public class UpdaterPlugin extends Plugin {
     coordinator.cleanupBundles(preparation.cleanupBundleIds);
     if (preparation.eventPayload != null) {
       sendDeviceEvent(preparation.eventPayload);
+      emitEvent(
+        "rollback",
+        failureEventData(
+          preparation.eventPayload.bundleVersion != null
+            ? preparation.eventPayload.bundleVersion
+            : "",
+          preparation.eventPayload.runtimeVersion,
+          preparation.eventPayload.channel,
+          preparation.eventPayload.releaseId,
+          reason
+        )
+      );
     }
 
     try {
@@ -1093,6 +1125,54 @@ public class UpdaterPlugin extends Plugin {
   private String resolveTargetChannel(String channel) {
     String resolved = trimToNull(channel);
     return resolved != null ? resolved : this.channel;
+  }
+
+  /**
+   * Emit a JS lifecycle event. notifyListeners marshals to the bridge
+   * safely from any thread, so no manual dispatch is needed.
+   */
+  private void emitEvent(String name, JSObject data) {
+    notifyListeners(name, data);
+  }
+
+  private JSObject failureEventData(
+    String version,
+    String runtimeVersion,
+    String channel,
+    String releaseId,
+    String reason
+  ) {
+    JSObject data = new JSObject();
+    data.put("version", version);
+    data.put("reason", reason);
+    if (trimToNull(runtimeVersion) != null) {
+      data.put("runtimeVersion", runtimeVersion.trim());
+    }
+    if (trimToNull(channel) != null) {
+      data.put("channel", channel.trim());
+    }
+    if (trimToNull(releaseId) != null) {
+      data.put("releaseId", releaseId.trim());
+    }
+    return data;
+  }
+
+  /** Map a native error to a stable event reason string. */
+  private String failureReason(Exception e) {
+    String message = e.getMessage() != null ? e.getMessage().toLowerCase() : "";
+    if (message.contains("hash mismatch")) {
+      return "hash_mismatch";
+    }
+    if (message.contains("disk space")) {
+      return "insufficient_disk_space";
+    }
+    if (message.contains("index.html")) {
+      return "invalid_bundle";
+    }
+    if (message.contains("zip") || message.contains("extract")) {
+      return "extract_failed";
+    }
+    return "download_failed";
   }
 
   private void sendDeviceEvent(

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
@@ -1169,7 +1169,12 @@ public class UpdaterPlugin extends Plugin {
     if (message.contains("index.html")) {
       return "invalid_bundle";
     }
-    if (message.contains("zip") || message.contains("extract")) {
+    // ZipUtils throws SecurityException for guard violations and prefixes
+    // its messages with "Zip ". Don't match ".zip" anywhere in the message:
+    // network failures often carry the temp file path (…/otakit-….zip).
+    if (
+      e instanceof SecurityException || message.startsWith("zip ") || message.contains("extract")
+    ) {
       return "extract_failed";
     }
     return "download_failed";

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
@@ -413,6 +413,9 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     coordinator.cleanupBundles(preparation.cleanupBundleIds)
     if let eventPayload = preparation.eventPayload {
       sendDeviceEvent(eventPayload)
+      // eventPayload is non-nil only on a genuine trial -> success transition,
+      // so repeat notifyAppReady() calls never double-emit.
+      emitEvent("updateApplied", ["bundle": store.getCurrentBundle().toDictionary()])
     }
 
     call.resolve()
@@ -462,6 +465,10 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     let resolution = try classifyLatestManifest(manifest, targetChannel: targetChannel)
+
+    if case let .updateAvailable(available) = resolution {
+      emitEvent("updateAvailable", manifestToDictionary(available))
+    }
 
     if respectInterval {
       recordCheckTimestamp()
@@ -599,6 +606,16 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
           releaseId: releaseId,
           detail: "insufficient_disk_space"
         )
+        emitEvent(
+          "downloadFailed",
+          failureEventData(
+            version: version,
+            runtimeVersion: runtimeVersion,
+            channel: channel,
+            releaseId: releaseId,
+            reason: "insufficient_disk_space"
+          )
+        )
         throw error
       }
     }
@@ -665,6 +682,7 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         channel: channel,
         releaseId: releaseId
       )
+      emitEvent("updateStaged", ["bundle": info.toDictionary()])
       return info
     } catch {
       sendDeviceEvent(
@@ -674,6 +692,16 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         channel: channel,
         releaseId: releaseId,
         detail: error.localizedDescription
+      )
+      emitEvent(
+        "downloadFailed",
+        failureEventData(
+          version: version,
+          runtimeVersion: runtimeVersion,
+          channel: channel,
+          releaseId: releaseId,
+          reason: failureReason(from: error)
+        )
       )
       throw error
     }
@@ -778,6 +806,16 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     coordinator.cleanupBundles(preparation.cleanupBundleIds)
     if let eventPayload = preparation.eventPayload {
       sendDeviceEvent(eventPayload)
+      emitEvent(
+        "rollback",
+        failureEventData(
+          version: eventPayload.bundleVersion ?? "",
+          runtimeVersion: eventPayload.runtimeVersion,
+          channel: eventPayload.channel,
+          releaseId: eventPayload.releaseId,
+          reason: reason
+        )
+      )
     }
 
     do {
@@ -941,6 +979,53 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     let digest = SHA256.hash(data: Data(identitySource.utf8))
     let suffix = digest.map { String(format: "%02x", $0) }.joined().prefix(12)
     return "\(normalized)-\(suffix)"
+  }
+
+  /// Emit a JS lifecycle event. `notifyListeners` marshals to the bridge
+  /// safely from any thread, so no manual dispatch is needed.
+  private func emitEvent(_ name: String, _ data: [String: Any]) {
+    notifyListeners(name, data: data)
+  }
+
+  private func failureEventData(
+    version: String,
+    runtimeVersion: String?,
+    channel: String?,
+    releaseId: String?,
+    reason: String
+  ) -> [String: Any] {
+    var data: [String: Any] = [
+      "version": version,
+      "reason": reason,
+    ]
+    if let runtimeVersion = trimToNil(runtimeVersion) {
+      data["runtimeVersion"] = runtimeVersion
+    }
+    if let channel = trimToNil(channel) {
+      data["channel"] = channel
+    }
+    if let releaseId = trimToNil(releaseId) {
+      data["releaseId"] = releaseId
+    }
+    return data
+  }
+
+  /// Map a native error to a stable event reason string.
+  private func failureReason(from error: Error) -> String {
+    if error is ZipUtilsError {
+      return "extract_failed"
+    }
+    let description = error.localizedDescription.lowercased()
+    if description.contains("hash mismatch") {
+      return "hash_mismatch"
+    }
+    if description.contains("disk space") {
+      return "insufficient_disk_space"
+    }
+    if description.contains("index.html") {
+      return "invalid_bundle"
+    }
+    return "download_failed"
   }
 
   private func sendDeviceEvent(

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
@@ -620,7 +620,32 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
       }
     }
 
-    let zipURL = try await downloader.download(from: url)
+    let zipURL: URL
+    do {
+      zipURL = try await downloader.download(from: url)
+    } catch {
+      // Network failures must report like every other download-path failure
+      // (Android's downloadZip already sits inside its try block).
+      sendDeviceEvent(
+        action: .downloadError,
+        bundleVersion: version,
+        runtimeVersion: runtimeVersion,
+        channel: channel,
+        releaseId: releaseId,
+        detail: error.localizedDescription
+      )
+      emitEvent(
+        "downloadFailed",
+        failureEventData(
+          version: version,
+          runtimeVersion: runtimeVersion,
+          channel: channel,
+          releaseId: releaseId,
+          reason: failureReason(from: error)
+        )
+      )
+      throw error
+    }
 
     let extractDirectory = fileManager.temporaryDirectory
       .appendingPathComponent("otakit-extract-\(UUID().uuidString)", isDirectory: true)

--- a/packages/capacitor-plugin/src/definitions.ts
+++ b/packages/capacitor-plugin/src/definitions.ts
@@ -1,3 +1,5 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
 /**
  * Bundle status enum.
  */
@@ -93,6 +95,49 @@ export interface DownloadStagedResult {
 export type DownloadResult = DownloadNoUpdateResult | DownloadStagedResult;
 
 /**
+ * Payload for the `updateStaged` event: a bundle was downloaded, verified,
+ * and staged, ready to apply.
+ */
+export interface UpdateStagedEvent {
+  bundle: BundleInfo;
+}
+
+/**
+ * Payload for the `updateApplied` event: a newly activated bundle was
+ * confirmed healthy via notifyAppReady().
+ */
+export interface UpdateAppliedEvent {
+  bundle: BundleInfo;
+}
+
+/**
+ * Payload for the `downloadFailed` and `rollback` events.
+ */
+export interface UpdateFailedEvent {
+  version: string;
+  runtimeVersion?: string;
+  releaseId?: string;
+  channel?: string;
+  /** Stable failure reason, e.g. "hash_mismatch", "insufficient_disk_space", "notify_timeout". */
+  reason: string;
+}
+
+/**
+ * Update lifecycle events emitted by the plugin.
+ *
+ * Events fire only while the app process is alive. Reconcile with
+ * getState() and getLastFailure() on startup for anything that happened
+ * while no listener was attached (e.g. a bundle staged in a previous
+ * session, or a startup rollback).
+ */
+export type OtaKitEventName =
+  | 'updateAvailable'
+  | 'updateStaged'
+  | 'updateApplied'
+  | 'downloadFailed'
+  | 'rollback';
+
+/**
  * Plugin configuration for capacitor.config.ts.
  */
 export interface OtaKitConfig {
@@ -176,6 +221,41 @@ export interface OtaKitPlugin {
    * Returns null if no failure has occurred.
    */
   getLastFailure(): Promise<BundleInfo | null>;
+
+  /**
+   * Subscribe to update lifecycle events.
+   *
+   * Events fire only while the app is running. On startup, reconcile with
+   * getState() (anything staged while not listening) and getLastFailure()
+   * (startup rollbacks happen before JS boots and cannot reach a listener).
+   * apply() reloads the WebView and destroys the JS context, so attach
+   * `updateApplied` / `rollback` listeners early in app startup.
+   */
+  addListener(
+    eventName: 'updateAvailable',
+    listenerFunc: (latest: LatestVersion) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: 'updateStaged',
+    listenerFunc: (event: UpdateStagedEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: 'updateApplied',
+    listenerFunc: (event: UpdateAppliedEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: 'downloadFailed',
+    listenerFunc: (event: UpdateFailedEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: 'rollback',
+    listenerFunc: (event: UpdateFailedEvent) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Remove all registered event listeners.
+   */
+  removeAllListeners(): Promise<void>;
 }
 
 export interface OtaKitBridgePlugin {
@@ -186,4 +266,9 @@ export interface OtaKitBridgePlugin {
   update(): Promise<void>;
   notifyAppReady(): Promise<void>;
   getLastFailure(): Promise<BundleInfo | null>;
+  addListener(
+    eventName: OtaKitEventName,
+    listenerFunc: (event: unknown) => void,
+  ): Promise<PluginListenerHandle>;
+  removeAllListeners(): Promise<void>;
 }

--- a/packages/capacitor-plugin/src/index.ts
+++ b/packages/capacitor-plugin/src/index.ts
@@ -1,6 +1,6 @@
 import { registerPlugin } from '@capacitor/core';
 
-import type { OtaKitBridgePlugin, OtaKitPlugin, BundleInfo } from './definitions';
+import type { OtaKitBridgePlugin, OtaKitPlugin, BundleInfo, OtaKitEventName } from './definitions';
 
 const NativeOtaKit = registerPlugin<OtaKitBridgePlugin>('OtaKit', {
   web: () => import('./web').then((m) => new m.OtaKitWeb()),
@@ -30,6 +30,11 @@ const OtaKit: OtaKitPlugin = {
   notifyAppReady: () => NativeOtaKit.notifyAppReady(),
   getLastFailure: async (): Promise<BundleInfo | null> =>
     normalizeNullable(await NativeOtaKit.getLastFailure()),
+  // NativeOtaKit is the registerPlugin proxy, which implements Capacitor's
+  // listener API; this plain-object wrapper must forward it explicitly.
+  addListener: ((eventName: OtaKitEventName, listenerFunc: (event: unknown) => void) =>
+    NativeOtaKit.addListener(eventName, listenerFunc)) as OtaKitPlugin['addListener'],
+  removeAllListeners: () => NativeOtaKit.removeAllListeners(),
 };
 
 export * from './definitions';

--- a/packages/site/app/docs/DocsSidebar.tsx
+++ b/packages/site/app/docs/DocsSidebar.tsx
@@ -32,6 +32,7 @@ const NAV = [
       { label: 'React Guide', href: '/docs/react' },
       { label: 'Channels & Runtime Version', href: '/docs/channels' },
       { label: 'Update Strategies', href: '/docs/update-strategies' },
+      { label: 'Events & Listeners', href: '/docs/events' },
       { label: 'CI automation', href: '/docs/ci' },
       { label: 'Self-hosting', href: '/docs/self-host' },
     ],

--- a/packages/site/app/docs/events/page.tsx
+++ b/packages/site/app/docs/events/page.tsx
@@ -1,0 +1,206 @@
+import Link from 'next/link';
+import { Separator } from '@/components/ui/separator';
+import { Pre } from '@/app/docs/CodeBlock';
+
+export const metadata = {
+  title: 'Events & Listeners',
+  description:
+    'Subscribe to update lifecycle events — update available, staged, applied, failed, rolled back.',
+};
+
+export default function EventsPage() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold tracking-tight">Events &amp; Listeners</h1>
+      <P>
+        The plugin emits lifecycle events through the standard Capacitor listener API. Events
+        complement — they don&apos;t replace — the pull APIs <Code>check()</Code> and{' '}
+        <Code>getState()</Code>: listeners tell you the moment something happens while your app is
+        running, and the pull APIs reconcile anything that happened while it wasn&apos;t.
+      </P>
+      <Pre>{`import { OtaKit } from '@otakit/capacitor-updater';
+
+OtaKit.addListener('updateStaged', ({ bundle }) => {
+  // show "Update ready — restart now?" and call OtaKit.apply() on accept
+});`}</Pre>
+
+      <Separator className="my-10" />
+
+      <h2 className="text-xl font-semibold tracking-tight">Event reference</h2>
+      <div className="mt-4 space-y-3">
+        <EventRow
+          event="updateAvailable"
+          payload="LatestVersion"
+          description="A check found a newer bundle, before any download starts. Fires on manual check() and at the start of automatic flows."
+        />
+        <EventRow
+          event="updateStaged"
+          payload="{ bundle: BundleInfo }"
+          description="A bundle was downloaded, verified, and staged, ready to apply. Download and stage are atomic in OtaKit, so this is the single 'downloaded' event."
+        />
+        <EventRow
+          event="updateApplied"
+          payload="{ bundle: BundleInfo }"
+          description="A newly activated bundle was confirmed healthy — fires when notifyAppReady() confirms the trial bundle, in the reloaded JS context."
+        />
+        <EventRow
+          event="downloadFailed"
+          payload="{ version, runtimeVersion?, releaseId?, channel?, reason }"
+          description="A download, verification, or extraction failed. Non-terminal: the app keeps running its current bundle and retries on a later cycle."
+        />
+        <EventRow
+          event="rollback"
+          payload="{ version, runtimeVersion?, releaseId?, channel?, reason }"
+          description="An applied bundle failed its health check (notifyAppReady timeout) and was reverted to the previous bundle."
+        />
+      </div>
+
+      <Separator className="my-10" />
+
+      <h2 className="text-xl font-semibold tracking-tight">Caveats</h2>
+      <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
+        <li>
+          <strong>Events fire only while the app process is alive.</strong> Nothing is delivered for
+          work that happened while the app was killed or before your listener attached — there is no
+          buffering or replay.
+        </li>
+        <li>
+          <strong>
+            Reconcile with <Code>getState()</Code> and <Code>getLastFailure()</Code> on startup.
+          </strong>{' '}
+          A bundle staged in a previous session shows up in <Code>getState().staged</Code>, and a
+          startup rollback (the app restarted before <Code>notifyAppReady()</Code>) happens before
+          any JS runs, so it can only be observed via <Code>getLastFailure()</Code>.
+        </li>
+        <li>
+          <strong>
+            <Code>apply()</Code> destroys the old JS context.
+          </strong>{' '}
+          A listener registered before the restart will not see <Code>updateApplied</Code> — that
+          event fires in the reloaded bundle. Attach <Code>updateApplied</Code> and{' '}
+          <Code>rollback</Code> listeners early in app startup, not inside the restart click
+          handler.
+        </li>
+        <li>
+          <strong>
+            One <Code>updateStaged</Code>, no separate &quot;downloaded&quot; event.
+          </strong>{' '}
+          Download, hash verification, and staging are one atomic operation.
+        </li>
+      </ul>
+      <P>The apply timeline, end to end:</P>
+      <Pre>{`updateStaged            (old context)
+  -> user taps "Restart"
+  -> OtaKit.apply()      (old JS context ends here; WebView reloads)
+  -> new bundle boots
+  -> app calls notifyAppReady()
+  -> updateApplied       (NEW context - attach this listener at startup)`}</Pre>
+
+      <Separator className="my-10" />
+
+      <h2 className="text-xl font-semibold tracking-tight">Use cases</h2>
+
+      <H3>Auto-download in the background, prompt to apply</H3>
+      <P>
+        Let <Code>shadow</Code> mode do the background checking, downloading, throttling, and
+        deduplication for you, and only handle the prompt yourself:
+      </P>
+      <Pre>{`// capacitor.config.ts
+plugins: {
+  OtaKit: { launchPolicy: 'shadow', resumePolicy: 'shadow' }
+}`}</Pre>
+      <Pre>{`// app startup
+const state = await OtaKit.getState();
+if (state.staged) showRestartPrompt(state.staged);
+OtaKit.addListener('updateStaged', ({ bundle }) => showRestartPrompt(bundle));
+
+// in the prompt's accept handler
+await OtaKit.apply();`}</Pre>
+
+      <H3>Prompt before downloading</H3>
+      <P>
+        Gate the download itself (for users on metered connections) by pairing manual mode with{' '}
+        <Code>updateAvailable</Code>:
+      </P>
+      <Pre>{`// capacitor.config.ts: { launchPolicy: 'off', resumePolicy: 'off' }
+OtaKit.addListener('updateAvailable', async (latest) => {
+  if (await confirmDownload(latest.version)) {
+    await OtaKit.download(); // emits updateStaged when done
+  }
+});
+await OtaKit.check();`}</Pre>
+
+      <H3>Post-update toast and failure reporting</H3>
+      <Pre>{`// attach at startup, in the reloaded bundle
+OtaKit.addListener('updateApplied', ({ bundle }) => {
+  toast('Updated to ' + bundle.version);
+});
+OtaKit.addListener('downloadFailed', (e) => reportError('ota_download', e));
+OtaKit.addListener('rollback', (e) => reportError('ota_rollback', e));
+
+// startup rollbacks can't reach a listener - reconcile:
+const failure = await OtaKit.getLastFailure();
+if (failure) reportError('ota_rollback_startup', failure);`}</Pre>
+
+      <Separator className="my-10" />
+
+      <h2 className="text-xl font-semibold tracking-tight">Cleanup</h2>
+      <P>
+        <Code>addListener</Code> resolves to a <Code>PluginListenerHandle</Code>; call{' '}
+        <Code>.remove()</Code> on it when the owning UI unmounts, or{' '}
+        <Code>OtaKit.removeAllListeners()</Code> to drop everything at once.
+      </P>
+
+      <Separator className="my-10" />
+
+      <P>
+        Also see{' '}
+        <Link
+          href="/docs/update-strategies"
+          className="font-medium text-foreground underline underline-offset-4"
+        >
+          Update Strategies
+        </Link>{' '}
+        for choosing the policies these events observe, and the{' '}
+        <Link
+          href="/docs/plugin"
+          className="font-medium text-foreground underline underline-offset-4"
+        >
+          Plugin API
+        </Link>{' '}
+        reference for the full method list.
+      </P>
+    </>
+  );
+}
+
+function EventRow({
+  event,
+  payload,
+  description,
+}: {
+  event: string;
+  payload: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="font-mono text-sm">
+        {event} <span className="text-muted-foreground">({payload})</span>
+      </div>
+      <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+function H3({ children }: { children: React.ReactNode }) {
+  return <h3 className="mt-6 text-sm font-semibold tracking-tight">{children}</h3>;
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return <p className="mt-3 text-sm text-muted-foreground">{children}</p>;
+}
+
+function Code({ children }: { children: React.ReactNode }) {
+  return <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{children}</code>;
+}

--- a/packages/site/app/docs/page.tsx
+++ b/packages/site/app/docs/page.tsx
@@ -114,6 +114,11 @@ export default function DocsOverviewPage() {
           description="How launchPolicy, resumePolicy, and runtimePolicy combine to control when updates apply."
         />
         <NavCard
+          href="/docs/events"
+          title="Events & Listeners"
+          description="Subscribe to update lifecycle events: available, staged, applied, failed, rolled back."
+        />
+        <NavCard
           href="/docs/ci"
           title="CI Automation"
           description="Build and ship bundles from GitHub Actions."

--- a/packages/site/app/docs/plugin/page.tsx
+++ b/packages/site/app/docs/plugin/page.tsx
@@ -271,9 +271,16 @@ await OtaKit.notifyAppReady();`}</Pre>
         />
       </div>
       <P>
-        There is no listener API in the current plugin surface. If you want custom update UI, use{' '}
-        <Code>check()</Code>, <Code>getState()</Code>, <Code>download()</Code>, and{' '}
-        <Code>apply()</Code> directly.
+        The plugin also emits lifecycle events — <Code>updateAvailable</Code>,{' '}
+        <Code>updateStaged</Code>, <Code>updateApplied</Code>, <Code>downloadFailed</Code>, and{' '}
+        <Code>rollback</Code> — via <Code>OtaKit.addListener(...)</Code>. See{' '}
+        <Link
+          href="/docs/events"
+          className="font-medium text-foreground underline underline-offset-4"
+        >
+          Events &amp; Listeners
+        </Link>{' '}
+        for the full reference and the startup reconciliation pattern.
       </P>
       <P>
         After a successful <Code>apply()</Code> or an <Code>update()</Code> that installs a new

--- a/packages/site/public/llms.txt
+++ b/packages/site/public/llms.txt
@@ -13,6 +13,7 @@ Generated from the public docs pages in `packages/site/app/docs`.
 - React Guide: /docs/react
 - Channels: /docs/channels
 - Update Strategies: /docs/update-strategies
+- Events & Listeners: /docs/events
 - CI Automation: /docs/ci
 - Security: /docs/security
 - Self-hosting: /docs/self-host
@@ -48,6 +49,7 @@ Start with the quick setup
 - **Next.js Guide**: Go from Next.js + Capacitor to your first OTA update.
 - **Channels & Runtimes**: Rollout tracks vs runtime compatibility lanes, and when to use each.
 - **Update Strategies**: How launchPolicy, resumePolicy, and runtimePolicy combine to control when updates apply.
+- **Events & Listeners**: Subscribe to update lifecycle events: available, staged, applied, failed, rolled back.
 - **CI Automation**: Build and ship bundles from GitHub Actions.
 - **CLI Reference**: Commands, options, and release workflows.
 - **Plugin API**: Default automatic flow, manual flow, and configuration.
@@ -508,7 +510,7 @@ plugins: {
 - `notifyAppReady()` -> `void`: Still required after the updated bundle launches. Call this once when your app has fully loaded so the plugin can mark the new bundle healthy.
 - `getLastFailure()` -> `BundleInfo | null`: Returns information about the most recent failed update (rollback). Useful for diagnostics and crash reporting. Returns null if no failure has occurred.
 
-There is no listener API in the current plugin surface. If you want custom update UI, use `check()`, `getState()`, `download()`, and `apply()` directly.
+The plugin also emits lifecycle events — `updateAvailable`, `updateStaged`, `updateApplied`, `downloadFailed`, and `rollback` — via `OtaKit.addListener(...)`. See Events & Listeners for the full reference and the startup reconciliation pattern.
 
 After a successful `apply()` or an `update()` that installs a new bundle, the app reloads immediately. Call `notifyAppReady()` from the reloaded app startup, not in the same JS flow that triggered the activation.
 
@@ -1215,6 +1217,104 @@ Set `launchPolicy` and `resumePolicy` to `shadow`. Bundles stage in the backgrou
 Turn `launchPolicy`, `resumePolicy`, and `runtimePolicy` all `off`, then drive the lifecycle yourself with `check()`, `download()`, and `apply()`. Use this when your app wants to show its own update prompt or control install timing precisely — see the Manual Flow section of the Plugin API reference for the full pattern.
 
 Also see Channels & Runtime Version for how rollout audience and native compatibility lanes interact with these policies.
+
+## Events & Listeners
+
+Route: /docs/events
+
+Subscribe to update lifecycle events — update available, staged, applied, failed, rolled back.
+
+The plugin emits lifecycle events through the standard Capacitor listener API. Events complement — they don't replace — the pull APIs `check()` and `getState()`: listeners tell you the moment something happens while your app is running, and the pull APIs reconcile anything that happened while it wasn't.
+
+```txt
+import { OtaKit } from '@otakit/capacitor-updater';
+
+OtaKit.addListener('updateStaged', ({ bundle }) => {
+  // show "Update ready — restart now?" and call OtaKit.apply() on accept
+});
+```
+
+### Event reference
+- `updateAvailable` (LatestVersion): A check found a newer bundle, before any download starts. Fires on manual check() and at the start of automatic flows.
+- `updateStaged` ({ bundle: BundleInfo }): A bundle was downloaded, verified, and staged, ready to apply. Download and stage are atomic in OtaKit, so this is the single 'downloaded' event.
+- `updateApplied` ({ bundle: BundleInfo }): A newly activated bundle was confirmed healthy — fires when notifyAppReady() confirms the trial bundle, in the reloaded JS context.
+- `downloadFailed` ({ version, runtimeVersion?, releaseId?, channel?, reason }): A download, verification, or extraction failed. Non-terminal: the app keeps running its current bundle and retries on a later cycle.
+- `rollback` ({ version, runtimeVersion?, releaseId?, channel?, reason }): An applied bundle failed its health check (notifyAppReady timeout) and was reverted to the previous bundle.
+
+### Caveats
+- Events fire only while the app process is alive. Nothing is delivered for work that happened while the app was killed or before your listener attached — there is no buffering or replay.
+- Reconcile with `getState()` and `getLastFailure()` on startup. A bundle staged in a previous session shows up in `getState().staged`, and a startup rollback (the app restarted before `notifyAppReady()`) happens before any JS runs, so it can only be observed via `getLastFailure()`.
+- `apply()` destroys the old JS context. A listener registered before the restart will not see `updateApplied` — that event fires in the reloaded bundle. Attach `updateApplied` and `rollback` listeners early in app startup, not inside the restart click handler.
+- One `updateStaged`, no separate "downloaded" event. Download, hash verification, and staging are one atomic operation.
+
+The apply timeline, end to end:
+
+```txt
+updateStaged            (old context)
+  -> user taps "Restart"
+  -> OtaKit.apply()      (old JS context ends here; WebView reloads)
+  -> new bundle boots
+  -> app calls notifyAppReady()
+  -> updateApplied       (NEW context - attach this listener at startup)
+```
+
+### Use cases
+
+#### Auto-download in the background, prompt to apply
+
+Let `shadow` mode do the background checking, downloading, throttling, and deduplication for you, and only handle the prompt yourself:
+
+```txt
+// capacitor.config.ts
+plugins: {
+  OtaKit: { launchPolicy: 'shadow', resumePolicy: 'shadow' }
+}
+```
+
+```txt
+// app startup
+const state = await OtaKit.getState();
+if (state.staged) showRestartPrompt(state.staged);
+OtaKit.addListener('updateStaged', ({ bundle }) => showRestartPrompt(bundle));
+
+// in the prompt's accept handler
+await OtaKit.apply();
+```
+
+#### Prompt before downloading
+
+Gate the download itself (for users on metered connections) by pairing manual mode with `updateAvailable`:
+
+```txt
+// capacitor.config.ts: { launchPolicy: 'off', resumePolicy: 'off' }
+OtaKit.addListener('updateAvailable', async (latest) => {
+  if (await confirmDownload(latest.version)) {
+    await OtaKit.download(); // emits updateStaged when done
+  }
+});
+await OtaKit.check();
+```
+
+#### Post-update toast and failure reporting
+
+```txt
+// attach at startup, in the reloaded bundle
+OtaKit.addListener('updateApplied', ({ bundle }) => {
+  toast('Updated to ' + bundle.version);
+});
+OtaKit.addListener('downloadFailed', (e) => reportError('ota_download', e));
+OtaKit.addListener('rollback', (e) => reportError('ota_rollback', e));
+
+// startup rollbacks can't reach a listener - reconcile:
+const failure = await OtaKit.getLastFailure();
+if (failure) reportError('ota_rollback_startup', failure);
+```
+
+### Cleanup
+
+`addListener` resolves to a `PluginListenerHandle`; call `.remove()` on it when the owning UI unmounts, or `OtaKit.removeAllListeners()` to drop everything at once.
+
+Also see Update Strategies for choosing the policies these events observe, and the Plugin API reference for the full method list.
 
 ## CI Automation
 

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -21,6 +21,11 @@ const DOCS = [
     route: '/docs/update-strategies',
     file: 'packages/site/app/docs/update-strategies/page.tsx',
   },
+  {
+    label: 'Events & Listeners',
+    route: '/docs/events',
+    file: 'packages/site/app/docs/events/page.tsx',
+  },
   { label: 'CI Automation', route: '/docs/ci', file: 'packages/site/app/docs/ci/page.tsx' },
   { label: 'Security', route: '/docs/security', file: 'packages/site/app/docs/security/page.tsx' },
   {


### PR DESCRIPTION
## What

Implements plan 07: five JS-observable update lifecycle events, making every policy mode observable without polling — the headline pattern being background `shadow` download + `updateStaged` listener + "Restart to update?" prompt.

| Event | Payload | Fires when |
|---|---|---|
| `updateAvailable` | `LatestVersion` | check finds a newer bundle, before download |
| `updateStaged` | `{ bundle: BundleInfo }` | bundle downloaded + verified + staged (atomic — the single "downloaded" event) |
| `updateApplied` | `{ bundle: BundleInfo }` | trial bundle confirmed healthy (`notifyAppReady`), in the reloaded JS context |
| `downloadFailed` | `{ version, …, reason }` | non-terminal download/verify/extract error (stable `reason` strings) |
| `rollback` | `{ version, …, reason }` | applied bundle reverted on notify timeout |

## Design notes

- Every emission co-locates with an existing `sendDeviceEvent` telemetry call — no new control flow or locks. `updateApplied` emits only when `prepareNotifyAppReady` returns a payload (genuine trial→success), so repeat calls never double-emit.
- **Startup rollbacks are deliberately not emitted**: they happen in `load()` before any JS listener can exist, so an event would always be lost. Docs prescribe `getLastFailure()` reconciliation instead.
- The plain-object JS wrapper (`index.ts`) now forwards `addListener`/`removeAllListeners` to the `registerPlugin` proxy, with typed per-event overloads on `OtaKitPlugin`.
- No event buffering/replay (documented non-goal); `downloadProgress` deferred to Phase 2 (iOS plumbing already exists in `Downloader.swift`).

## Docs

New `/docs/events` page (house style, `EventRow` markup consumed by the llms.txt generator), sidebar + overview NavCard, replaced the "There is no listener API" sentence on the Plugin API page, plugin README Events section.

## Verification

- `pnpm --filter @otakit/capacitor-updater typecheck` ✅ · `build` (tsc + rollup) ✅ · `eslint src` ✅
- `pnpm --filter @otakit/site typecheck` ✅
- `xcrun swiftc -parse` on `UpdaterPlugin.swift` (+ `ZipUtils.swift`) ✅
- `node scripts/generate-llms-txt.mjs` ✅ — events page renders into llms.txt via the existing `EventRow` handler
- prettier (TS/TSX/Java/MD) ✅
- Not verified: native compile on device/emulator (no Android SDK build or Xcode project build run); no automated tests exist in this repo yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)