### PR TITLE
feat(cli): native compatibility guardrail at upload time

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,16 +36,18 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "yazl": "^2.5.1",
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "dotenv": "^17.2.3",
-    "ora": "^9.1.0"
+    "ora": "^9.1.0",
+    "semver": "^7.8.5",
+    "yazl": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
-    "@types/yazl": "^2.4.5",
     "@types/node": "^25.2.0",
+    "@types/semver": "^7.7.1",
+    "@types/yazl": "^2.4.5",
     "eslint": "^9.39.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.32.1"

--- a/packages/cli/src/commands/compatibility.ts
+++ b/packages/cli/src/commands/compatibility.ts
@@ -1,0 +1,55 @@
+import { Command } from 'commander';
+
+import { ApiClient } from '../lib/api.js';
+import { checkCompatibilityAgainstChannel } from '../lib/compat-check.js';
+import { requireConfig } from '../lib/config.js';
+import { CliError, runCommand } from '../lib/errors.js';
+import { collectNativePackages, formatCompatibilityReport } from '../lib/native-deps.js';
+import { normalizeChannel } from '../lib/validate.js';
+
+type CompatibilityOptions = {
+  appId?: string;
+  server?: string;
+  channel?: string;
+  failOnIncompatible?: boolean;
+  packageJson?: string;
+  nodeModules?: string;
+};
+
+export const compatibilityCommand = new Command('compatibility')
+  .description("Compare local native dependencies against a channel's current release")
+  .option('--app-id <id>', 'App ID override')
+  .option('--server <url>', 'Server URL override')
+  .option('--channel <name>', 'Release channel to compare against (default: base channel)')
+  .option('--fail-on-incompatible', 'Exit non-zero when the check reports incompatible')
+  .option('--package-json <path>', 'package.json used for native dependency detection')
+  .option('--node-modules <path>', 'node_modules used for native dependency detection')
+  .action(async (options: CompatibilityOptions) => {
+    await runCommand(async () => {
+      const config = await requireConfig({
+        appId: options.appId,
+        serverUrl: options.server,
+      });
+      const api = new ApiClient(config);
+
+      const channel = options.channel === undefined ? null : normalizeChannel(options.channel);
+
+      const nativePackages = collectNativePackages({
+        packageJsonPath: options.packageJson,
+        nodeModulesPath: options.nodeModules,
+      });
+
+      const result = await checkCompatibilityAgainstChannel({
+        api,
+        channel,
+        runtimeVersion: config.runtimeVersion,
+        nativePackages,
+      });
+
+      console.log(formatCompatibilityReport(result));
+
+      if (result.status === 'incompatible' && options.failOnIncompatible) {
+        throw new CliError('Incompatible native changes detected.');
+      }
+    });
+  });

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -3,8 +3,14 @@ import { Command } from 'commander';
 import ora from 'ora';
 
 import { ApiClient } from '../lib/api.js';
+import { checkCompatibilityAgainstChannel } from '../lib/compat-check.js';
 import { requireConfig } from '../lib/config.js';
-import { runCommand } from '../lib/errors.js';
+import { CliError, runCommand } from '../lib/errors.js';
+import {
+  collectNativePackages,
+  formatCompatibilityReport,
+  type NativePackage,
+} from '../lib/native-deps.js';
 import { resolveBundlePath, resolveVersion, runUploadWorkflow } from '../lib/upload-workflow.js';
 import { normalizeChannel } from '../lib/validate.js';
 
@@ -14,6 +20,10 @@ type UploadOptions = {
   version?: string;
   strictVersion?: boolean;
   release?: string | boolean;
+  failOnIncompatible?: boolean;
+  ignoreCompat?: boolean;
+  packageJson?: string;
+  nodeModules?: string;
 };
 
 function resolveReleaseChannel(
@@ -38,6 +48,10 @@ export const uploadCommand = new Command('upload')
   .option('--version <version>', 'Version string (default: OTAKIT_VERSION, then auto-generated)')
   .option('--strict-version', 'Require explicit version (--version or OTAKIT_VERSION)')
   .option('--release [channel]', 'Release after upload (base channel if omitted)')
+  .option('--fail-on-incompatible', 'Exit non-zero when native compatibility check fails')
+  .option('--ignore-compat', 'Skip the native compatibility check')
+  .option('--package-json <path>', 'package.json used for native dependency detection')
+  .option('--node-modules <path>', 'node_modules used for native dependency detection')
   .action(async (path: string | undefined, options: UploadOptions) => {
     await runCommand(async () => {
       const config = await requireConfig({
@@ -60,6 +74,41 @@ export const uploadCommand = new Command('upload')
 
       const releaseChannel = resolveReleaseChannel(options.release);
 
+      // Always capture the native set so this upload becomes the baseline for
+      // the next one; --ignore-compat only skips the comparison.
+      let nativePackages: NativePackage[] | undefined;
+      try {
+        nativePackages = collectNativePackages({
+          packageJsonPath: options.packageJson,
+          nodeModulesPath: options.nodeModules,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`Skipping native dependency detection: ${message}`);
+      }
+
+      if (nativePackages && !options.ignoreCompat) {
+        // Compare against the channel this bundle is headed for; a plain
+        // upload without --release is checked against the base channel.
+        const targetChannel = releaseChannel === undefined ? null : releaseChannel;
+        const result = await checkCompatibilityAgainstChannel({
+          api,
+          channel: targetChannel,
+          runtimeVersion: config.runtimeVersion,
+          nativePackages,
+        });
+
+        if (result.status === 'incompatible') {
+          console.error(formatCompatibilityReport(result));
+          if (options.failOnIncompatible) {
+            throw new CliError('Upload blocked: incompatible native changes detected.');
+          }
+          console.warn('Continuing upload despite incompatible native changes (warning only).');
+        } else if (result.status === 'skipped') {
+          console.log('Native compatibility check skipped (no baseline on this channel/lane yet).');
+        }
+      }
+
       const spinner = ora('Creating zip archive...').start();
 
       const bundle = await (async () => {
@@ -70,6 +119,7 @@ export const uploadCommand = new Command('upload')
             version,
             runtimeVersion: config.runtimeVersion,
             releaseChannel,
+            nativePackages,
             onStatus: (message) => {
               spinner.text = message;
             },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 
+import { compatibilityCommand } from './commands/compatibility.js';
 import { configCommand } from './commands/config.js';
 import { registerCommand } from './commands/register.js';
 import { uploadCommand } from './commands/upload.js';
@@ -25,6 +26,7 @@ program
 program.addCommand(configCommand);
 program.addCommand(registerCommand);
 program.addCommand(uploadCommand);
+program.addCommand(compatibilityCommand);
 program.addCommand(releaseCommand);
 program.addCommand(listCommand);
 program.addCommand(deleteCommand);

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type { CliConfig } from './config.js';
 import { fetchCli } from './http.js';
+import type { NativePackage } from './native-deps.js';
 import { CLI_VERSION, getCliUserAgent } from './version.js';
 
 export interface Bundle {
@@ -9,6 +10,10 @@ export interface Bundle {
   size: number;
   runtimeVersion?: string | null;
   createdAt: string;
+}
+
+export interface BundleDetail extends Bundle {
+  nativePackages?: NativePackage[] | null;
 }
 
 export interface UploadInitResponse {
@@ -26,6 +31,7 @@ export interface Release {
   bundleVersion?: string;
   promotedAt: string;
   promotedBy?: string;
+  revertedAt?: string | null;
 }
 
 export class ApiClient {
@@ -97,11 +103,16 @@ export class ApiClient {
     runtimeVersion?: string;
     size: number;
     sha256: string;
+    nativePackages?: NativePackage[];
   }): Promise<UploadInitResponse> {
     return this.fetch(this.appPath('/bundles/initiate'), {
       method: 'POST',
       body: JSON.stringify(options),
     });
+  }
+
+  async getBundle(bundleId: string): Promise<BundleDetail> {
+    return this.fetch(this.appPath(`/bundles/${encodeURIComponent(bundleId)}`));
   }
 
   async finalizeUpload(options: { uploadId: string }): Promise<Bundle> {

--- a/packages/cli/src/lib/compat-check.ts
+++ b/packages/cli/src/lib/compat-check.ts
@@ -16,7 +16,9 @@ export async function checkCompatibilityAgainstChannel(options: {
 }): Promise<CompatibilityResult> {
   const { api, channel, runtimeVersion, nativePackages } = options;
 
-  const { releases } = await api.listReleases(channel, { limit: 50 });
+  // 200 is the API's max page size; a channel whose lane baseline sits
+  // deeper than 200 releases back is treated as skipped (no baseline).
+  const { releases } = await api.listReleases(channel, { limit: 200 });
   const lane = runtimeVersion ?? null;
   const currentRelease = releases.find(
     (release) => !release.revertedAt && (release.runtimeVersion ?? null) === lane,

--- a/packages/cli/src/lib/compat-check.ts
+++ b/packages/cli/src/lib/compat-check.ts
@@ -1,0 +1,35 @@
+import type { ApiClient } from './api.js';
+import { compareNative, type CompatibilityResult, type NativePackage } from './native-deps.js';
+
+/**
+ * Resolve the channel's current (non-reverted) release in the same
+ * runtimeVersion lane and compare the local native set against its bundle.
+ *
+ * Returns `skipped` when the channel has no current release in this lane or
+ * the current bundle predates native package capture.
+ */
+export async function checkCompatibilityAgainstChannel(options: {
+  api: ApiClient;
+  channel: string | null;
+  runtimeVersion: string | undefined;
+  nativePackages: NativePackage[];
+}): Promise<CompatibilityResult> {
+  const { api, channel, runtimeVersion, nativePackages } = options;
+
+  const { releases } = await api.listReleases(channel, { limit: 50 });
+  const lane = runtimeVersion ?? null;
+  const currentRelease = releases.find(
+    (release) => !release.revertedAt && (release.runtimeVersion ?? null) === lane,
+  );
+  if (!currentRelease) {
+    return { status: 'skipped', findings: [] };
+  }
+
+  const bundle = await api.getBundle(currentRelease.bundleId);
+  const remote = bundle.nativePackages;
+  if (remote === null || remote === undefined) {
+    return { status: 'skipped', findings: [] };
+  }
+
+  return compareNative(nativePackages, remote);
+}

--- a/packages/cli/src/lib/native-deps.ts
+++ b/packages/cli/src/lib/native-deps.ts
@@ -230,6 +230,23 @@ function compareEntry(local: NativePackage, remote: NativePackage): Compatibilit
     remoteVersion: remote.version,
   };
 
+  // Native code added for a platform the baseline never had (e.g. a plugin
+  // gains Android sources): devices on that platform need a store build,
+  // same as a brand-new plugin. The reverse (remote-only checksum) is a
+  // removal and stays compatible.
+  const addedPlatforms = [
+    ['ios', local.iosChecksum, remote.iosChecksum],
+    ['android', local.androidChecksum, remote.androidChecksum],
+  ].filter(([, localSum, remoteSum]) => localSum !== undefined && remoteSum === undefined);
+  if (addedPlatforms.length > 0) {
+    return {
+      ...base,
+      kind: 'native_code_changed',
+      incompatible: true,
+      note: `native code added for ${addedPlatforms.map(([platform]) => platform).join(' + ')} (not in the current release)`,
+    };
+  }
+
   const comparablePlatforms: Array<[string | undefined, string | undefined]> = [
     [local.iosChecksum, remote.iosChecksum],
     [local.androidChecksum, remote.androidChecksum],

--- a/packages/cli/src/lib/native-deps.ts
+++ b/packages/cli/src/lib/native-deps.ts
@@ -1,0 +1,320 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+
+import semver from 'semver';
+
+import { CliError } from './errors.js';
+
+/**
+ * A dependency that ships native (iOS/Android) code, captured at upload time
+ * so later uploads can detect native changes that require a store build.
+ */
+export interface NativePackage {
+  name: string;
+  version: string;
+  requestedVersion?: string;
+  iosChecksum?: string;
+  androidChecksum?: string;
+}
+
+export interface CollectNativePackagesOptions {
+  /** Path to the project package.json. Defaults to ./package.json. */
+  packageJsonPath?: string;
+  /** Path to the resolved node_modules. Defaults to a sibling of package.json. */
+  nodeModulesPath?: string;
+}
+
+const NATIVE_FILE_REGEX = /\.(java|swift|kt|scala)$/;
+const IOS_SOURCE_REGEX = /\.swift$/;
+const ANDROID_SOURCE_REGEX = /\.(java|kt|scala)$/;
+const IOS_CONFIG_REGEX = /(\.podspec|(^|\/)Package\.swift)$/;
+const ANDROID_CONFIG_REGEX = /(^|\/)build\.gradle(\.kts)?$/;
+const SKIPPED_DIRECTORIES = new Set(['node_modules', '.git', 'dist', 'build']);
+
+export function collectNativePackages(options: CollectNativePackagesOptions = {}): NativePackage[] {
+  const packageJsonPath = resolve(options.packageJsonPath ?? join(process.cwd(), 'package.json'));
+  if (!existsSync(packageJsonPath)) {
+    throw new CliError(`package.json not found at ${packageJsonPath} (use --package-json).`);
+  }
+
+  const nodeModulesPath = resolve(
+    options.nodeModulesPath ?? join(dirname(packageJsonPath), 'node_modules'),
+  );
+  if (!existsSync(nodeModulesPath)) {
+    throw new CliError(`node_modules not found at ${nodeModulesPath} (use --node-modules).`);
+  }
+
+  const rootPackage = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+    dependencies?: Record<string, string>;
+  };
+  const dependencies = rootPackage.dependencies ?? {};
+
+  const nativePackages: NativePackage[] = [];
+  for (const [name, requestedVersion] of Object.entries(dependencies)) {
+    const packageDir = join(nodeModulesPath, ...name.split('/'));
+    const packageJson = join(packageDir, 'package.json');
+    if (!existsSync(packageJson)) {
+      continue;
+    }
+
+    let installedVersion: string;
+    try {
+      const parsed = JSON.parse(readFileSync(packageJson, 'utf-8')) as { version?: unknown };
+      if (typeof parsed.version !== 'string' || parsed.version.length === 0) {
+        continue;
+      }
+      installedVersion = parsed.version;
+    } catch {
+      continue;
+    }
+
+    const files = listFilesRecursively(packageDir);
+    const relativePaths = files
+      .map((file) => relative(packageDir, file).split(sep).join('/'))
+      .sort();
+
+    if (!relativePaths.some((path) => NATIVE_FILE_REGEX.test(path))) {
+      continue;
+    }
+
+    const iosChecksum = checksumForPlatform(
+      packageDir,
+      relativePaths,
+      IOS_SOURCE_REGEX,
+      IOS_CONFIG_REGEX,
+    );
+    const androidChecksum = checksumForPlatform(
+      packageDir,
+      relativePaths,
+      ANDROID_SOURCE_REGEX,
+      ANDROID_CONFIG_REGEX,
+    );
+
+    nativePackages.push({
+      name,
+      version: installedVersion,
+      requestedVersion,
+      ...(iosChecksum ? { iosChecksum } : {}),
+      ...(androidChecksum ? { androidChecksum } : {}),
+    });
+  }
+
+  return nativePackages.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function listFilesRecursively(directory: string): string[] {
+  const files: string[] = [];
+  const entries = readdirSync(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    const fullPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRECTORIES.has(entry.name)) {
+        files.push(...listFilesRecursively(fullPath));
+      }
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+/**
+ * SHA-256 over the platform's sorted native + config files, with each file's
+ * relative path mixed into the hash so renames are detected.
+ */
+function checksumForPlatform(
+  packageDir: string,
+  sortedRelativePaths: string[],
+  sourceRegex: RegExp,
+  configRegex: RegExp,
+): string | undefined {
+  const platformPaths = sortedRelativePaths.filter(
+    (path) => sourceRegex.test(path) || configRegex.test(path),
+  );
+  if (platformPaths.length === 0) {
+    return undefined;
+  }
+
+  const hash = createHash('sha256');
+  for (const path of platformPaths) {
+    hash.update(path);
+    hash.update('\0');
+    hash.update(readFileSync(join(packageDir, path)));
+    hash.update('\0');
+  }
+  return hash.digest('hex');
+}
+
+export type CompatibilityStatus = 'compatible' | 'incompatible' | 'skipped';
+
+export type FindingKind =
+  | 'new_plugin'
+  | 'native_code_changed'
+  | 'version_mismatch'
+  | 'range_changed'
+  | 'removed'
+  | 'unchanged';
+
+export interface CompatibilityFinding {
+  name: string;
+  kind: FindingKind;
+  incompatible: boolean;
+  localVersion?: string;
+  remoteVersion?: string;
+  note?: string;
+}
+
+export interface CompatibilityResult {
+  status: CompatibilityStatus;
+  findings: CompatibilityFinding[];
+}
+
+/**
+ * Compare the local native set against the channel's current bundle.
+ *
+ * The checksum is the authoritative "native code actually changed" signal;
+ * a changed requested-version range that resolves to identical native code
+ * is reported as informational only.
+ */
+export function compareNative(
+  local: NativePackage[],
+  remote: NativePackage[] | null | undefined,
+): CompatibilityResult {
+  if (remote === null || remote === undefined) {
+    return { status: 'skipped', findings: [] };
+  }
+
+  const remoteByName = new Map(remote.map((entry) => [entry.name, entry]));
+  const findings: CompatibilityFinding[] = [];
+
+  for (const pkg of local) {
+    const remotePkg = remoteByName.get(pkg.name);
+    remoteByName.delete(pkg.name);
+
+    if (!remotePkg) {
+      findings.push({
+        name: pkg.name,
+        kind: 'new_plugin',
+        incompatible: true,
+        localVersion: pkg.version,
+        note: 'native plugin not present in the current release',
+      });
+      continue;
+    }
+
+    findings.push(compareEntry(pkg, remotePkg));
+  }
+
+  for (const remotePkg of remoteByName.values()) {
+    findings.push({
+      name: remotePkg.name,
+      kind: 'removed',
+      incompatible: false,
+      remoteVersion: remotePkg.version,
+      note: 'removed locally (safe to ship OTA)',
+    });
+  }
+
+  const status = findings.some((finding) => finding.incompatible) ? 'incompatible' : 'compatible';
+  return { status, findings };
+}
+
+function compareEntry(local: NativePackage, remote: NativePackage): CompatibilityFinding {
+  const base = {
+    name: local.name,
+    localVersion: local.version,
+    remoteVersion: remote.version,
+  };
+
+  const comparablePlatforms: Array<[string | undefined, string | undefined]> = [
+    [local.iosChecksum, remote.iosChecksum],
+    [local.androidChecksum, remote.androidChecksum],
+  ].filter(([localSum, remoteSum]) => localSum !== undefined && remoteSum !== undefined) as Array<
+    [string, string]
+  >;
+
+  if (comparablePlatforms.length > 0) {
+    const changed = comparablePlatforms.some(([localSum, remoteSum]) => localSum !== remoteSum);
+    if (changed) {
+      return {
+        ...base,
+        kind: 'native_code_changed',
+        incompatible: true,
+        note: 'native code differs from the current release',
+      };
+    }
+    if (local.requestedVersion !== remote.requestedVersion) {
+      return {
+        ...base,
+        kind: 'range_changed',
+        incompatible: false,
+        note: `requested range changed (${remote.requestedVersion ?? '?'} -> ${local.requestedVersion ?? '?'}) but native code is identical`,
+      };
+    }
+    return { ...base, kind: 'unchanged', incompatible: false };
+  }
+
+  // No comparable checksums (older baseline data) — fall back to versions.
+  if (!versionsIntersect(local, remote)) {
+    return {
+      ...base,
+      kind: 'version_mismatch',
+      incompatible: true,
+      note: 'installed native versions do not intersect',
+    };
+  }
+  return { ...base, kind: 'unchanged', incompatible: false };
+}
+
+function versionsIntersect(local: NativePackage, remote: NativePackage): boolean {
+  const localRange = local.requestedVersion ?? local.version;
+  const remoteRange = remote.requestedVersion ?? remote.version;
+  try {
+    return semver.intersects(localRange, remoteRange, { includePrerelease: true });
+  } catch {
+    return local.version === remote.version;
+  }
+}
+
+export function formatCompatibilityReport(result: CompatibilityResult): string {
+  if (result.status === 'skipped') {
+    return 'Compatibility check skipped: the current release has no native package baseline yet.';
+  }
+
+  const lines: string[] = [];
+  const rows = result.findings.map((finding) => [
+    finding.incompatible ? 'INCOMPATIBLE' : finding.kind === 'unchanged' ? 'ok' : 'info',
+    finding.name,
+    finding.localVersion ?? '-',
+    finding.remoteVersion ?? '-',
+    finding.note ?? finding.kind,
+  ]);
+  const header = ['status', 'package', 'local', 'remote', 'detail'];
+  const widths = header.map((title, column) =>
+    Math.max(title.length, ...rows.map((row) => row[column].length)),
+  );
+  const renderRow = (row: string[]) =>
+    row.map((cell, column) => cell.padEnd(widths[column])).join('  ');
+
+  lines.push(renderRow(header));
+  lines.push(widths.map((width) => '-'.repeat(width)).join('  '));
+  for (const row of rows) {
+    lines.push(renderRow(row));
+  }
+  if (rows.length === 0) {
+    lines.push('(no native packages detected)');
+  }
+
+  if (result.status === 'incompatible') {
+    lines.push('');
+    lines.push(
+      'These native changes require a new store build. Bump runtimeVersion and ship a native build before releasing this bundle OTA.',
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/packages/cli/src/lib/upload-workflow.ts
+++ b/packages/cli/src/lib/upload-workflow.ts
@@ -8,6 +8,7 @@ import { tmpdir } from 'node:os';
 import type { ApiClient, Bundle } from './api.js';
 import { CliError } from './errors.js';
 import { hashFile } from './hash.js';
+import type { NativePackage } from './native-deps.js';
 import { getCliUserAgent } from './version.js';
 import { createZip, removeFileIfExists, validateBundleDirectory } from './zip.js';
 
@@ -132,6 +133,7 @@ export type UploadWorkflowOptions = {
   version: string;
   runtimeVersion?: string;
   releaseChannel?: string | null;
+  nativePackages?: NativePackage[];
   onStatus?: (message: string) => void;
 };
 
@@ -143,7 +145,8 @@ export type UploadWorkflowResult = {
 export async function runUploadWorkflow(
   options: UploadWorkflowOptions,
 ): Promise<UploadWorkflowResult> {
-  const { api, sourcePath, version, runtimeVersion, releaseChannel, onStatus } = options;
+  const { api, sourcePath, version, runtimeVersion, releaseChannel, nativePackages, onStatus } =
+    options;
 
   validateBundleDirectory(sourcePath);
 
@@ -173,6 +176,7 @@ export async function runUploadWorkflow(
       runtimeVersion,
       size: zipStat.size,
       sha256,
+      nativePackages,
     });
 
     const expiresAt = new Date(initiated.expiresAt);

--- a/packages/console/app/api/v1/apps/[appId]/bundles/[bundleId]/route.ts
+++ b/packages/console/app/api/v1/apps/[appId]/bundles/[bundleId]/route.ts
@@ -7,6 +7,46 @@ import { buildPublicObjectUrl, deleteBundleObject } from '@/lib/storage';
 
 export const runtime = 'nodejs';
 
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ appId: string; bundleId: string }> },
+) {
+  const routeParams = await params;
+  const appId = routeParams.appId;
+
+  const access = await resolveOrganizationAccess(request, appId);
+  if (!access.success) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  const bundle = await db.bundle.findUnique({
+    where: { id: routeParams.bundleId },
+    select: {
+      id: true,
+      appId: true,
+      version: true,
+      sha256: true,
+      size: true,
+      runtimeVersion: true,
+      nativePackages: true,
+      createdAt: true,
+    },
+  });
+  if (!bundle || bundle.appId !== appId) {
+    return NextResponse.json({ error: 'Bundle not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    id: bundle.id,
+    version: bundle.version,
+    sha256: bundle.sha256,
+    size: bundle.size,
+    runtimeVersion: bundle.runtimeVersion,
+    nativePackages: bundle.nativePackages,
+    createdAt: bundle.createdAt.toISOString(),
+  });
+}
+
 export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ appId: string; bundleId: string }> },

--- a/packages/console/app/api/v1/apps/[appId]/bundles/finalize/route.ts
+++ b/packages/console/app/api/v1/apps/[appId]/bundles/finalize/route.ts
@@ -129,6 +129,10 @@ export async function POST(
             session.metadata === null
               ? Prisma.JsonNull
               : (session.metadata as Prisma.InputJsonValue),
+          nativePackages:
+            session.nativePackages === null
+              ? Prisma.JsonNull
+              : (session.nativePackages as Prisma.InputJsonValue),
         },
       });
 

--- a/packages/console/app/api/v1/apps/[appId]/bundles/initiate/route.ts
+++ b/packages/console/app/api/v1/apps/[appId]/bundles/initiate/route.ts
@@ -7,6 +7,7 @@ import { db } from '@/lib/db';
 import { createPresignedUpload, getMaxBundleSize } from '@/lib/storage';
 import {
   isValidMetadata,
+  isValidNativePackages,
   isValidRuntimeVersion,
   isValidVersion,
   normalizeOptionalRuntimeVersion,
@@ -100,6 +101,17 @@ export async function POST(
     );
   }
 
+  const nativePackages = body.nativePackages;
+  if (!isValidNativePackages(nativePackages)) {
+    return NextResponse.json(
+      {
+        error:
+          'nativePackages must be an array of { name, version, requestedVersion?, iosChecksum?, androidChecksum? } (max 200 entries, 32KB)',
+      },
+      { status: 400 },
+    );
+  }
+
   const existing = await db.bundle.findUnique({
     where: {
       appId_version: { appId, version },
@@ -127,6 +139,10 @@ export async function POST(
       runtimeVersion,
       metadata:
         metadata === null ? Prisma.JsonNull : (metadata as Prisma.InputJsonValue | undefined),
+      nativePackages:
+        nativePackages === null
+          ? Prisma.JsonNull
+          : (nativePackages as Prisma.InputJsonValue | undefined),
       storageKey,
       expiresAt,
     },

--- a/packages/console/lib/validation.ts
+++ b/packages/console/lib/validation.ts
@@ -115,3 +115,41 @@ function checkDepth(obj: unknown, current: number, max: number): boolean {
   }
   return true;
 }
+
+const MAX_NATIVE_PACKAGES = 200;
+const MAX_NATIVE_PACKAGES_SIZE = 32768;
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+/**
+ * Validate the native package set the CLI attaches at upload time for the
+ * compatibility guardrail. Shape per entry:
+ * { name, version, requestedVersion?, iosChecksum?, androidChecksum? }
+ */
+export function isValidNativePackages(nativePackages: unknown): boolean {
+  if (nativePackages === null || nativePackages === undefined) {
+    return true;
+  }
+  if (!Array.isArray(nativePackages)) {
+    return false;
+  }
+  if (nativePackages.length > MAX_NATIVE_PACKAGES) {
+    return false;
+  }
+  if (JSON.stringify(nativePackages).length > MAX_NATIVE_PACKAGES_SIZE) {
+    return false;
+  }
+  return nativePackages.every(
+    (entry) =>
+      typeof entry === 'object' &&
+      entry !== null &&
+      !Array.isArray(entry) &&
+      typeof (entry as Record<string, unknown>).name === 'string' &&
+      typeof (entry as Record<string, unknown>).version === 'string' &&
+      isOptionalString((entry as Record<string, unknown>).requestedVersion) &&
+      isOptionalString((entry as Record<string, unknown>).iosChecksum) &&
+      isOptionalString((entry as Record<string, unknown>).androidChecksum),
+  );
+}

--- a/packages/console/prisma/migrations/20260701120000_bundle_native_packages/migration.sql
+++ b/packages/console/prisma/migrations/20260701120000_bundle_native_packages/migration.sql
@@ -1,0 +1,5 @@
+-- Native package set captured at upload time for the CLI compatibility
+-- guardrail. Stored on the upload session first, then carried onto the
+-- bundle at finalize (mirrors how "metadata" flows).
+ALTER TABLE "UploadSession" ADD COLUMN "nativePackages" JSONB;
+ALTER TABLE "Bundle" ADD COLUMN "nativePackages" JSONB;

--- a/packages/console/prisma/schema.prisma
+++ b/packages/console/prisma/schema.prisma
@@ -189,6 +189,7 @@ model Bundle {
   size               Int
   runtimeVersion     String?
   metadata           Json?
+  nativePackages     Json?
   createdAt          DateTime        @default(now())
   releases           Release[]       @relation("ReleaseBundle")
   previousInReleases Release[]       @relation("ReleasePreviousBundle")
@@ -226,6 +227,7 @@ model UploadSession {
   actualSize     Int?
   runtimeVersion String?
   metadata       Json?
+  nativePackages Json?
   storageKey     String
   status         UploadSessionStatus @default(initiated)
   bundle         Bundle?             @relation(fields: [bundleId], references: [id], onDelete: SetNull)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       ora:
         specifier: ^9.1.0
         version: 9.3.0
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
       yazl:
         specifier: ^2.5.1
         version: 2.5.1
@@ -148,6 +151,9 @@ importers:
       '@types/node':
         specifier: ^25.2.0
         version: 25.2.2
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@types/yazl':
         specifier: ^2.4.5
         version: 2.4.6
@@ -2362,6 +2368,9 @@ packages:
   '@types/react@19.2.13':
     resolution: {integrity: sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==}
 
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
   '@types/slice-ansi@4.0.0':
     resolution: {integrity: sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==}
 
@@ -4518,6 +4527,11 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -7410,6 +7424,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/semver@7.7.1': {}
+
   '@types/slice-ansi@4.0.0': {}
 
   '@types/yazl@2.4.6':
@@ -9726,6 +9742,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.5: {}
 
   set-cookie-parser@2.7.2: {}
 


### PR DESCRIPTION
## What

Implements [plan 03](docs/plans/03-cli-compatibility-guardrail.md): catch "shipped JS that needs native code the installed shell doesn't have" **at upload time**, before it crashes devices.

- `otakit upload` now detects native dependencies (any `.java/.swift/.kt/.scala` in the package), computes per-platform sha256 checksums (sorted native + config files — podspec / `Package.swift` / `build.gradle` — with relative paths mixed into the hash so renames are caught), sends the set on `initiate`, and compares against the target channel's current release **in the same `runtimeVersion` lane**.
- Warn by default; `--fail-on-incompatible` for CI gates; `--ignore-compat` to skip; `--package-json` / `--node-modules` for monorepos.
- New standalone `otakit compatibility --channel <name>` table report.
- Console: `Bundle.nativePackages` + `UploadSession.nativePackages` (JSONB), validated on initiate (≤200 entries / 32KB), carried through finalize; **new** `GET /bundles/[bundleId]` (route previously had only DELETE).

## Decision rules (vs Capgo)

New plugin → incompatible · checksum changed → incompatible · versions don't intersect → incompatible **only when checksums unavailable** · requested-range-string-only change → informational (checksum is authoritative, reduces false positives) · removed locally → compatible · no baseline (first release on channel/lane) → skipped.

## Verification

- `pnpm --filter @otakit/cli typecheck`, `lint`, `build` ✅
- `pnpm --filter @otakit/console typecheck` (after `db:generate`) ✅
- prettier on all changed files ✅
- Smoke test against `examples/demo-app`: detects `@capacitor/android`, `@capacitor/ios`, `@capacitor/splash-screen`, `@otakit/capacitor-updater` with per-platform checksums; self-compare → `compatible`, missing-remote → `incompatible` with correct table, null baseline → `skipped` ✅

⚠️ The Prisma migration (`20260701120000_bundle_native_packages`) is hand-written and was **not** run against a database (none available in this environment) — please run `pnpm db:migrate` against dev before merging.

Adds `semver` (+ `@types/semver`) to the CLI for range-intersection checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)