### PR TITLE
feat: forceImmediateUpdate per-release emergency flag

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1204,7 +1204,9 @@ OtaKit has one set of four policy values and three settings that decide when eac
 
 #### Ship critical fixes instantly
 
-Set `launchPolicy` and `resumePolicy` to `immediate` as well. Devices apply a fix as soon as they check — even mid-session on resume. Trade-off: users can see the app reload while they're using it, so reserve this for cases where landing the fix fast matters more than a seamless reload.
+Mark the release as force immediate — in the dashboard's release dialog or with `otakit release --force-immediate`. The flag is baked into the signed manifest, and devices on `shadow` or `apply-staged` policies escalate that one release to the immediate behavior: download, apply, and reload on their next check. No app rebuild, no config change.
+
+Bounds: it is "immediate on the next event/check", not push — delivery is bounded by lifecycle events and `checkInterval`. Policies set to `off` never fetch a manifest, so they never see the flag, and the trial/rollback safety net still applies. The reload can land mid-session, so reserve it for broken releases, not routine rollouts. (Compiling `immediate` policies into the app remains an option when you want this behavior for every release.)
 
 #### Update quietly, reload only with consent
 

--- a/packages/capacitor-plugin/README.md
+++ b/packages/capacitor-plugin/README.md
@@ -98,6 +98,25 @@ resumePolicy = 'off';
 runtimePolicy = 'off';
 ```
 
+## Force-immediate releases
+
+A release (or revert) can be marked **force immediate** in the dashboard or
+with `otakit release --force-immediate`. The flag is baked into the signed
+manifest; when a device's automatic flow sees it, `shadow` and `apply-staged`
+events escalate to the `immediate` behavior for that release: download, apply,
+and reload on that event.
+
+Bounds to keep in mind:
+
+- It is "immediate on the next event/check", not push — delivery is bounded by
+  lifecycle events and `checkInterval` (static CDN, no server→device channel).
+- `off` policies never fetch a manifest, so they never see the flag. `off`
+  stays the device-owned kill switch, and the manual APIs are unchanged.
+- Trial and rollback still apply: a forced bundle that never calls
+  `notifyAppReady()` rolls back like any other.
+- It reloads the app under the user, possibly mid-task. Use it for broken
+  releases, not routine rollouts.
+
 ## Check interval
 
 `checkInterval` defaults to 10 minutes and only applies to background resume

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
@@ -68,18 +68,24 @@ public class UpdaterPlugin extends Plugin {
 
     final String kind;
     final BundleInfo bundle;
+    final boolean forceImmediate;
 
-    private DownloadResolution(String kind, BundleInfo bundle) {
+    private DownloadResolution(String kind, BundleInfo bundle, boolean forceImmediate) {
       this.kind = kind;
       this.bundle = bundle;
+      this.forceImmediate = forceImmediate;
     }
 
     static DownloadResolution noUpdate() {
-      return new DownloadResolution("no_update", null);
+      return new DownloadResolution("no_update", null, false);
     }
 
-    static DownloadResolution staged(BundleInfo bundle) {
-      return new DownloadResolution("staged", bundle);
+    static DownloadResolution staged(BundleInfo bundle, boolean forceImmediate) {
+      return new DownloadResolution("staged", bundle, forceImmediate);
+    }
+
+    boolean isForcedStaged() {
+      return "staged".equals(kind) && forceImmediate;
     }
   }
 
@@ -290,14 +296,20 @@ public class UpdaterPlugin extends Plugin {
           return;
         }
         executeAutomaticUpdate("runtime apply-staged fallback", () -> {
-          downloadLatest(false, null);
+          DownloadResolution result = downloadLatest(false, null);
           resolveCurrentRuntimeKey();
+          if (result.isForcedStaged()) {
+            requireApplyStaged(true);
+          }
         });
         return;
       case SHADOW:
         executeAutomaticUpdate("runtime shadow", () -> {
-          downloadLatest(false, null);
+          DownloadResolution result = downloadLatest(false, null);
           resolveCurrentRuntimeKey();
+          if (result.isForcedStaged()) {
+            requireApplyStaged(true);
+          }
         });
         return;
       case IMMEDIATE:
@@ -327,10 +339,20 @@ public class UpdaterPlugin extends Plugin {
           android.util.Log.w("OtaKit", "launch apply-staged failed", e);
           return;
         }
-        executeAutomaticUpdate("launch apply-staged fallback", () -> downloadLatest(false, null));
+        executeAutomaticUpdate("launch apply-staged fallback", () -> {
+          DownloadResolution result = downloadLatest(false, null);
+          if (result.isForcedStaged()) {
+            requireApplyStaged(true);
+          }
+        });
         return;
       case SHADOW:
-        executeAutomaticUpdate("launch shadow", () -> downloadLatest(false, null));
+        executeAutomaticUpdate("launch shadow", () -> {
+          DownloadResolution result = downloadLatest(false, null);
+          if (result.isForcedStaged()) {
+            requireApplyStaged(true);
+          }
+        });
         return;
       case IMMEDIATE:
         executeAutomaticUpdate("launch immediate", () -> {
@@ -352,11 +374,19 @@ public class UpdaterPlugin extends Plugin {
           if (applyStaged(true)) {
             return;
           }
-          downloadLatest(true, null);
+          DownloadResolution result = downloadLatest(true, null);
+          if (result.isForcedStaged()) {
+            requireApplyStaged(true);
+          }
         });
         return;
       case SHADOW:
-        executeAutomaticUpdate("resume shadow", () -> downloadLatest(true, null));
+        executeAutomaticUpdate("resume shadow", () -> {
+          DownloadResolution result = downloadLatest(true, null);
+          if (result.isForcedStaged()) {
+            requireApplyStaged(true);
+          }
+        });
         return;
       case IMMEDIATE:
         executeAutomaticUpdate("resume immediate", () -> {
@@ -572,10 +602,13 @@ public class UpdaterPlugin extends Plugin {
       case "no_update":
         return DownloadResolution.noUpdate();
       case "already_staged":
-        return DownloadResolution.staged(result.bundle);
+        return DownloadResolution.staged(result.bundle, result.latest.forceImmediate);
       case "update_available":
         try {
-          return DownloadResolution.staged(downloadLatestManifest(result.latest, targetChannel));
+          return DownloadResolution.staged(
+            downloadLatestManifest(result.latest, targetChannel),
+            result.latest.forceImmediate
+          );
         } catch (Exception e) {
           if (!isExpiredURLError(e)) {
             throw e;
@@ -591,10 +624,14 @@ public class UpdaterPlugin extends Plugin {
             case "no_update":
               return DownloadResolution.noUpdate();
             case "already_staged":
-              return DownloadResolution.staged(refreshedResolution.bundle);
+              return DownloadResolution.staged(
+                refreshedResolution.bundle,
+                refreshedResolution.latest.forceImmediate
+              );
             case "update_available":
               return DownloadResolution.staged(
-                downloadLatestManifest(refreshedResolution.latest, targetChannel)
+                downloadLatestManifest(refreshedResolution.latest, targetChannel),
+                refreshedResolution.latest.forceImmediate
               );
             default:
               throw new IllegalStateException(
@@ -935,6 +972,7 @@ public class UpdaterPlugin extends Plugin {
       object.put("runtimeVersion", latest.runtimeVersion);
     }
     object.put("releaseId", latest.releaseId);
+    object.put("forceImmediate", latest.forceImmediate);
     return object;
   }
 

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
@@ -20,7 +20,7 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
 
   private enum DownloadResolution {
     case noUpdate
-    case staged(BundleInfo)
+    case staged(BundleInfo, forceImmediate: Bool)
   }
 
   public let identifier = "UpdaterPlugin"
@@ -196,13 +196,19 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         return
       }
       executeAutomaticUpdate(label: "runtime apply-staged fallback") { [self] in
-        _ = try await downloadLatest(respectInterval: false, channel: nil)
+        let result = try await downloadLatest(respectInterval: false, channel: nil)
         resolveCurrentRuntimeKey()
+        if isForcedStaged(result) {
+          try requireApplyStaged(reloadAfterApply: true)
+        }
       }
     case .shadow:
       executeAutomaticUpdate(label: "runtime shadow") { [self] in
-        _ = try await downloadLatest(respectInterval: false, channel: nil)
+        let result = try await downloadLatest(respectInterval: false, channel: nil)
         resolveCurrentRuntimeKey()
+        if isForcedStaged(result) {
+          try requireApplyStaged(reloadAfterApply: true)
+        }
       }
     case .immediate:
       executeAutomaticUpdate(label: "runtime immediate") { [self] in
@@ -232,11 +238,17 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         return
       }
       executeAutomaticUpdate(label: "launch apply-staged fallback") { [self] in
-        _ = try await downloadLatest(respectInterval: false, channel: nil)
+        let result = try await downloadLatest(respectInterval: false, channel: nil)
+        if isForcedStaged(result) {
+          try requireApplyStaged(reloadAfterApply: true)
+        }
       }
     case .shadow:
       executeAutomaticUpdate(label: "launch shadow") { [self] in
-        _ = try await downloadLatest(respectInterval: false, channel: nil)
+        let result = try await downloadLatest(respectInterval: false, channel: nil)
+        if isForcedStaged(result) {
+          try requireApplyStaged(reloadAfterApply: true)
+        }
       }
     case .immediate:
       executeAutomaticUpdate(label: "launch immediate") { [self] in
@@ -257,11 +269,17 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         if try applyStaged(reloadAfterApply: true) {
           return
         }
-        _ = try await downloadLatest(respectInterval: true, channel: nil)
+        let result = try await downloadLatest(respectInterval: true, channel: nil)
+        if isForcedStaged(result) {
+          try requireApplyStaged(reloadAfterApply: true)
+        }
       }
     case .shadow:
       executeAutomaticUpdate(label: "resume shadow") { [self] in
-        _ = try await downloadLatest(respectInterval: true, channel: nil)
+        let result = try await downloadLatest(respectInterval: true, channel: nil)
+        if isForcedStaged(result) {
+          try requireApplyStaged(reloadAfterApply: true)
+        }
       }
     case .immediate:
       executeAutomaticUpdate(label: "resume immediate") { [self] in
@@ -478,15 +496,15 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     switch result {
     case .noUpdate:
       return .noUpdate
-    case let .alreadyStaged(_, bundle):
-      return .staged(bundle)
+    case let .alreadyStaged(latest, bundle):
+      return .staged(bundle, forceImmediate: latest.forceImmediate)
     case let .updateAvailable(manifest):
       do {
         let bundle = try await downloadLatestManifest(
           manifest,
           targetChannel: targetChannel
         )
-        return .staged(bundle)
+        return .staged(bundle, forceImmediate: manifest.forceImmediate)
       } catch let error as NSError where isExpiredURLError(error) {
         guard let refreshed = try await fetchLatest(channel: targetChannel) else {
           return .noUpdate
@@ -495,14 +513,14 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
         switch try classifyLatestManifest(refreshed, targetChannel: targetChannel) {
         case .noUpdate:
           return .noUpdate
-        case let .alreadyStaged(_, bundle):
-          return .staged(bundle)
+        case let .alreadyStaged(latest, bundle):
+          return .staged(bundle, forceImmediate: latest.forceImmediate)
         case let .updateAvailable(retryManifest):
           let bundle = try await downloadLatestManifest(
             retryManifest,
             targetChannel: targetChannel
           )
-          return .staged(bundle)
+          return .staged(bundle, forceImmediate: retryManifest.forceImmediate)
         }
       }
     }
@@ -555,12 +573,21 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     switch result {
     case .noUpdate:
       return ["kind": "no_update"]
-    case let .staged(bundle):
+    case let .staged(bundle, _):
       return [
         "kind": "staged",
         "bundle": bundle.toDictionary(),
       ]
     }
+  }
+
+  /// True when an automatic flow staged a bundle whose release is marked
+  /// force-immediate — the flow escalates to apply + reload.
+  private func isForcedStaged(_ result: DownloadResolution) -> Bool {
+    if case let .staged(_, forceImmediate) = result {
+      return forceImmediate
+    }
+    return false
   }
 
   private func isExpiredURLError(_ error: NSError) -> Bool {
@@ -863,6 +890,7 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
       payload["runtimeVersion"] = runtimeVersion
     }
     payload["releaseId"] = latest.releaseId
+    payload["forceImmediate"] = latest.forceImmediate
     return payload
   }
 

--- a/packages/capacitor-plugin/src/definitions.ts
+++ b/packages/capacitor-plugin/src/definitions.ts
@@ -46,6 +46,12 @@ export interface LatestVersion {
   size: number;
   /** Release history ID associated with this manifest */
   releaseId: string;
+  /**
+   * True when the release is marked force-immediate: automatic flows apply
+   * and reload it on the next lifecycle event regardless of shadow or
+   * apply-staged policies. Manual API behavior is unchanged.
+   */
+  forceImmediate?: boolean;
 }
 
 export interface OtaKitState {

--- a/packages/cli/src/commands/release.ts
+++ b/packages/cli/src/commands/release.ts
@@ -11,6 +11,7 @@ type ReleaseOptions = {
   appId?: string;
   server?: string;
   channel?: string;
+  forceImmediate?: boolean;
 };
 
 export const releaseCommand = new Command('release')
@@ -19,6 +20,10 @@ export const releaseCommand = new Command('release')
   .option('--app-id <id>', 'App ID override')
   .option('--server <url>', 'Server URL override')
   .option('--channel <channel>', 'Channel name (omit for the base channel)')
+  .option(
+    '--force-immediate',
+    'Devices apply and reload this release on their next check (emergency fixes)',
+  )
   .action(async (bundleId: string | undefined, options: ReleaseOptions) => {
     await runCommand(async () => {
       const config = await requireConfig({
@@ -28,11 +33,13 @@ export const releaseCommand = new Command('release')
       const api = new ApiClient(config);
       const channel = options.channel ? normalizeChannel(options.channel) : null;
       const targetLabel = channel ?? 'base channel';
+      const forceImmediate = options.forceImmediate === true;
+      const forceLabel = forceImmediate ? ' (force immediate)' : '';
 
       if (bundleId) {
         const spinner = ora(`Releasing ${bundleId} to ${targetLabel}...`).start();
-        await api.release(channel, bundleId);
-        spinner.succeed(`Released ${bundleId} to ${targetLabel}.`);
+        await api.release(channel, bundleId, { forceImmediate });
+        spinner.succeed(`Released ${bundleId} to ${targetLabel}${forceLabel}.`);
         return;
       }
 
@@ -45,7 +52,7 @@ export const releaseCommand = new Command('release')
 
       const latest = bundles[0];
       spinner.text = `Releasing ${latest.version} to ${targetLabel}...`;
-      await api.release(channel, latest.id);
-      spinner.succeed(`Released ${latest.version} to ${targetLabel}.`);
+      await api.release(channel, latest.id, { forceImmediate });
+      spinner.succeed(`Released ${latest.version} to ${targetLabel}${forceLabel}.`);
     });
   });

--- a/packages/cli/src/commands/releases.ts
+++ b/packages/cli/src/commands/releases.ts
@@ -64,8 +64,9 @@ export const releasesCommand = new Command('releases')
 
       for (const release of response.releases) {
         const bundleVersion = release.bundleVersion ? ` (${release.bundleVersion})` : '';
+        const forceLabel = release.forceImmediate ? ' [force-immediate]' : '';
         console.log(
-          `${formatReleaseLane(release.channel, release.runtimeVersion)}: ${release.bundleId}${bundleVersion} at ${release.promotedAt}`,
+          `${formatReleaseLane(release.channel, release.runtimeVersion)}: ${release.bundleId}${bundleVersion}${forceLabel} at ${release.promotedAt}`,
         );
       }
       console.log(`Total: ${response.total}`);

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -65,6 +65,10 @@ export const uploadCommand = new Command('upload')
 
       const releaseChannel = resolveReleaseChannel(options.release);
 
+      if (options.forceImmediate === true && releaseChannel === undefined) {
+        console.warn('--force-immediate has no effect without --release; ignoring.');
+      }
+
       const spinner = ora('Creating zip archive...').start();
 
       const bundle = await (async () => {

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -14,6 +14,7 @@ type UploadOptions = {
   version?: string;
   strictVersion?: boolean;
   release?: string | boolean;
+  forceImmediate?: boolean;
 };
 
 function resolveReleaseChannel(
@@ -38,6 +39,10 @@ export const uploadCommand = new Command('upload')
   .option('--version <version>', 'Version string (default: OTAKIT_VERSION, then auto-generated)')
   .option('--strict-version', 'Require explicit version (--version or OTAKIT_VERSION)')
   .option('--release [channel]', 'Release after upload (base channel if omitted)')
+  .option(
+    '--force-immediate',
+    'With --release: devices apply and reload on their next check (emergency fixes)',
+  )
   .action(async (path: string | undefined, options: UploadOptions) => {
     await runCommand(async () => {
       const config = await requireConfig({
@@ -70,6 +75,7 @@ export const uploadCommand = new Command('upload')
             version,
             runtimeVersion: config.runtimeVersion,
             releaseChannel,
+            forceImmediate: options.forceImmediate === true,
             onStatus: (message) => {
               spinner.text = message;
             },

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -24,6 +24,7 @@ export interface Release {
   runtimeVersion?: string | null;
   bundleId: string;
   bundleVersion?: string;
+  forceImmediate?: boolean;
   promotedAt: string;
   promotedBy?: string;
 }
@@ -132,10 +133,15 @@ export class ApiClient {
   async release(
     channel: string | null,
     bundleId: string,
+    options?: { forceImmediate?: boolean },
   ): Promise<{ release: Release; previousRelease: Release | null }> {
     return this.fetch(this.appPath('/releases'), {
       method: 'POST',
-      body: JSON.stringify({ bundleId, channel }),
+      body: JSON.stringify({
+        bundleId,
+        channel,
+        forceImmediate: options?.forceImmediate ?? false,
+      }),
     });
   }
 

--- a/packages/cli/src/lib/upload-workflow.ts
+++ b/packages/cli/src/lib/upload-workflow.ts
@@ -132,6 +132,7 @@ export type UploadWorkflowOptions = {
   version: string;
   runtimeVersion?: string;
   releaseChannel?: string | null;
+  forceImmediate?: boolean;
   onStatus?: (message: string) => void;
 };
 
@@ -143,7 +144,8 @@ export type UploadWorkflowResult = {
 export async function runUploadWorkflow(
   options: UploadWorkflowOptions,
 ): Promise<UploadWorkflowResult> {
-  const { api, sourcePath, version, runtimeVersion, releaseChannel, onStatus } = options;
+  const { api, sourcePath, version, runtimeVersion, releaseChannel, forceImmediate, onStatus } =
+    options;
 
   validateBundleDirectory(sourcePath);
 
@@ -190,7 +192,7 @@ export async function runUploadWorkflow(
 
     if (releaseChannel !== undefined) {
       onStatus?.(`Releasing to ${releaseChannel ?? 'base channel'}...`);
-      await api.release(releaseChannel, bundle.id);
+      await api.release(releaseChannel, bundle.id, { forceImmediate });
     }
 
     return { bundle, releaseChannel };

--- a/packages/console/app/api/v1/apps/[appId]/releases/[releaseId]/revert/route.ts
+++ b/packages/console/app/api/v1/apps/[appId]/releases/[releaseId]/revert/route.ts
@@ -20,6 +20,19 @@ export async function POST(
     return NextResponse.json({ error: access.error }, { status: access.status });
   }
 
+  // The body is optional (existing clients POST without one); when present it
+  // may carry a forceImmediate override for the release that becomes current.
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    body = {};
+  }
+  const rawForceImmediate = body.forceImmediate;
+  if (rawForceImmediate !== undefined && typeof rawForceImmediate !== 'boolean') {
+    return NextResponse.json({ error: 'forceImmediate must be a boolean' }, { status: 400 });
+  }
+
   const targetRelease = await db.release.findFirst({
     where: { id: releaseId, appId },
     include: {
@@ -85,6 +98,18 @@ export async function POST(
     }),
   ]);
 
+  let effectiveNextCurrentRelease = nextCurrentRelease;
+  if (rawForceImmediate !== undefined && nextCurrentRelease) {
+    effectiveNextCurrentRelease = await db.release.update({
+      where: { id: nextCurrentRelease.id },
+      data: { forceImmediate: rawForceImmediate },
+      include: {
+        bundle: { select: { version: true, runtimeVersion: true } },
+        previousBundle: { select: { version: true } },
+      },
+    });
+  }
+
   await syncManifestFileForLane(appId, targetRelease.channel, targetRelease.bundle.runtimeVersion);
 
   return NextResponse.json({
@@ -101,19 +126,20 @@ export async function POST(
       revertedAt: revertedAt.toISOString(),
       revertedBy,
     },
-    currentRelease: nextCurrentRelease
+    currentRelease: effectiveNextCurrentRelease
       ? {
-          id: nextCurrentRelease.id,
-          channel: nextCurrentRelease.channel,
-          runtimeVersion: nextCurrentRelease.bundle.runtimeVersion,
-          bundleId: nextCurrentRelease.bundleId,
-          bundleVersion: nextCurrentRelease.bundle.version,
-          previousBundleId: nextCurrentRelease.previousBundleId,
-          previousBundleVersion: nextCurrentRelease.previousBundle?.version ?? null,
-          promotedAt: nextCurrentRelease.promotedAt.toISOString(),
-          promotedBy: nextCurrentRelease.promotedBy,
-          revertedAt: nextCurrentRelease.revertedAt?.toISOString() ?? null,
-          revertedBy: nextCurrentRelease.revertedBy,
+          id: effectiveNextCurrentRelease.id,
+          channel: effectiveNextCurrentRelease.channel,
+          runtimeVersion: effectiveNextCurrentRelease.bundle.runtimeVersion,
+          bundleId: effectiveNextCurrentRelease.bundleId,
+          bundleVersion: effectiveNextCurrentRelease.bundle.version,
+          previousBundleId: effectiveNextCurrentRelease.previousBundleId,
+          previousBundleVersion: effectiveNextCurrentRelease.previousBundle?.version ?? null,
+          forceImmediate: effectiveNextCurrentRelease.forceImmediate,
+          promotedAt: effectiveNextCurrentRelease.promotedAt.toISOString(),
+          promotedBy: effectiveNextCurrentRelease.promotedBy,
+          revertedAt: effectiveNextCurrentRelease.revertedAt?.toISOString() ?? null,
+          revertedBy: effectiveNextCurrentRelease.revertedBy,
         }
       : null,
   });

--- a/packages/console/app/api/v1/apps/[appId]/releases/route.ts
+++ b/packages/console/app/api/v1/apps/[appId]/releases/route.ts
@@ -87,6 +87,7 @@ export async function GET(
       bundleVersion: release.bundle.version,
       previousBundleId: release.previousBundleId,
       previousBundleVersion: release.previousBundle?.version ?? null,
+      forceImmediate: release.forceImmediate,
       promotedAt: release.promotedAt.toISOString(),
       promotedBy: release.promotedBy,
       revertedAt: release.revertedAt?.toISOString() ?? null,
@@ -136,6 +137,12 @@ export async function POST(
     return NextResponse.json({ error: 'Invalid channel' }, { status: 400 });
   }
 
+  const rawForceImmediate = body.forceImmediate;
+  if (rawForceImmediate !== undefined && typeof rawForceImmediate !== 'boolean') {
+    return NextResponse.json({ error: 'forceImmediate must be a boolean' }, { status: 400 });
+  }
+  const forceImmediate = rawForceImmediate === true;
+
   const bundle = await db.bundle.findUnique({
     where: { id: bundleId },
     select: { id: true, appId: true, version: true, runtimeVersion: true },
@@ -172,6 +179,7 @@ export async function POST(
     bundleId: bundle.id,
     previousBundleId: currentLatest?.bundleId ?? null,
     channel,
+    forceImmediate,
     promotedBy,
   });
   await syncManifestFileForLane(appId, channel, bundle.runtimeVersion);
@@ -184,6 +192,7 @@ export async function POST(
       bundleId: release.bundleId,
       bundleVersion: bundle.version,
       previousBundleId: release.previousBundleId,
+      forceImmediate: release.forceImmediate,
       promotedAt: release.promotedAt.toISOString(),
       promotedBy: release.promotedBy,
       revertedAt: null,

--- a/packages/console/app/components/ProductDashboard.tsx
+++ b/packages/console/app/components/ProductDashboard.tsx
@@ -452,6 +452,7 @@ export function ProductDashboard({
     bundle: BundleSummaryItem;
     selectedTargetKey: string;
     newChannelName: string;
+    forceImmediate: boolean;
   } | null>(null);
 
   // Revert
@@ -461,6 +462,7 @@ export function ProductDashboard({
     runtimeVersion: string | null;
     currentVersion: string;
     previousVersion: string | null;
+    forceImmediate: boolean;
   } | null>(null);
   const [revertBusy, setRevertBusy] = useState(false);
 
@@ -815,12 +817,14 @@ export function ProductDashboard({
         getReleaseTargetsForRuntime(releaseTargets, bundle.runtimeVersion),
       ),
       newChannelName: '',
+      forceImmediate: false,
     });
   }
 
   async function releaseBundle(
     bundle: BundleSummaryItem,
     target: ReleaseTarget | null,
+    forceImmediate = false,
   ): Promise<boolean> {
     if (!selectedAppId || !target) return false;
     if (isCurrentOnTarget(bundle, target.channel, target.runtimeVersion)) {
@@ -838,7 +842,7 @@ export function ProductDashboard({
       const res = await fetch(`/api/v1/apps/${encodeURIComponent(selectedAppId)}/releases`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bundleId: bundle.id, channel: target.channel }),
+        body: JSON.stringify({ bundleId: bundle.id, channel: target.channel, forceImmediate }),
       });
       const data = await parseJson<ApiError>(res);
       if (!res.ok) throw new Error(data.error ?? 'Release failed');
@@ -866,7 +870,11 @@ export function ProductDashboard({
     if (releaseChannelError || releaseChannelMissing) {
       return;
     }
-    await releaseBundle(releaseConfirm.bundle, releaseSelectedTarget);
+    await releaseBundle(
+      releaseConfirm.bundle,
+      releaseSelectedTarget,
+      releaseConfirm.forceImmediate,
+    );
   }
 
   function openRevertConfirm(row: ReleaseHistoryItem) {
@@ -876,6 +884,7 @@ export function ProductDashboard({
       runtimeVersion: row.runtimeVersion,
       currentVersion: row.bundleVersion,
       previousVersion: row.previousBundleVersion ?? null,
+      forceImmediate: false,
     });
   }
 
@@ -887,6 +896,8 @@ export function ProductDashboard({
         `/api/v1/apps/${encodeURIComponent(selectedAppId)}/releases/${encodeURIComponent(revertConfirm.releaseId)}/revert`,
         {
           method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(revertConfirm.forceImmediate ? { forceImmediate: true } : {}),
         },
       );
       const data = await parseJson<ApiError>(res);
@@ -1354,6 +1365,16 @@ export function ProductDashboard({
                                                               </span>
                                                               <span className="truncate font-mono">
                                                                 {rel.previousBundleVersion}
+                                                              </span>
+                                                            </>
+                                                          ) : null}
+                                                          {rel?.forceImmediate ? (
+                                                            <>
+                                                              <span className="text-muted-foreground">
+                                                                Rollout
+                                                              </span>
+                                                              <span className="font-medium text-amber-600 dark:text-amber-400">
+                                                                Force immediate
                                                               </span>
                                                             </>
                                                           ) : null}
@@ -1872,6 +1893,27 @@ export function ProductDashboard({
                 <span className="text-muted-foreground">Release to</span>
                 <code className="font-mono text-xs">{releaseConfirm.bundle.version}</code>
               </div>
+              <div className="flex items-start gap-2">
+                <Checkbox
+                  id="release-force-immediate"
+                  checked={releaseConfirm.forceImmediate}
+                  onCheckedChange={(checked) =>
+                    setReleaseConfirm((current) =>
+                      current ? { ...current, forceImmediate: checked === true } : current,
+                    )
+                  }
+                  disabled={releaseConfirmBusy}
+                />
+                <div className="grid gap-1 leading-none">
+                  <Label htmlFor="release-force-immediate" className="text-sm font-normal">
+                    Force immediate update
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Devices apply and reload on their next check. For broken releases, not routine
+                    rollouts.
+                  </p>
+                </div>
+              </div>
               {releaseAlreadyCurrent ? (
                 <p className="text-xs text-muted-foreground">
                   This bundle is already current on{' '}
@@ -1956,6 +1998,28 @@ export function ProductDashboard({
                   bundle.
                 </p>
               )}
+              {revertConfirm.previousVersion ? (
+                <div className="flex items-start gap-2">
+                  <Checkbox
+                    id="revert-force-immediate"
+                    checked={revertConfirm.forceImmediate}
+                    onCheckedChange={(checked) =>
+                      setRevertConfirm((current) =>
+                        current ? { ...current, forceImmediate: checked === true } : current,
+                      )
+                    }
+                    disabled={revertBusy}
+                  />
+                  <div className="grid gap-1 leading-none">
+                    <Label htmlFor="revert-force-immediate" className="text-sm font-normal">
+                      Force immediate update
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Devices apply and reload the reverted-to release on their next check.
+                    </p>
+                  </div>
+                </div>
+              ) : null}
             </div>
           ) : null}
           <DialogFooter>

--- a/packages/console/app/components/dashboard-types.ts
+++ b/packages/console/app/components/dashboard-types.ts
@@ -88,6 +88,7 @@ export type ReleaseHistoryItem = {
   bundleVersion: string;
   previousBundleId: string | null;
   previousBundleVersion: string | null;
+  forceImmediate: boolean;
   promotedAt: string;
   promotedBy: string | null;
   revertedAt: string | null;

--- a/packages/console/lib/manifest-files.ts
+++ b/packages/console/lib/manifest-files.ts
@@ -23,6 +23,7 @@ type ManifestBundle = {
 
 type ManifestRelease = {
   id: string;
+  forceImmediate: boolean;
 };
 
 export function getManifestChannelKey(channel: string | null): string {
@@ -65,7 +66,7 @@ export async function writeManifestFile(
     size: bundle.size,
     runtimeVersion: bundle.runtimeVersion,
     strategy: 'zip',
-    forceImmediate: false,
+    forceImmediate: release.forceImmediate,
     encryption: null,
   });
 
@@ -80,7 +81,7 @@ export async function writeManifestFile(
       runtimeVersion: bundle.runtimeVersion,
       releaseId: release.id,
       strategy: 'zip',
-      forceImmediate: false,
+      forceImmediate: release.forceImmediate,
       signature,
     }),
     contentType: 'application/json; charset=utf-8',

--- a/packages/console/lib/releases.ts
+++ b/packages/console/lib/releases.ts
@@ -7,6 +7,7 @@ export async function createRelease(
     bundleId: string;
     previousBundleId?: string | null;
     channel: string | null;
+    forceImmediate?: boolean;
     promotedBy?: string;
   },
 ): Promise<Release> {
@@ -16,6 +17,7 @@ export async function createRelease(
       bundleId: input.bundleId,
       previousBundleId: input.previousBundleId ?? null,
       channel: input.channel,
+      forceImmediate: input.forceImmediate ?? false,
       promotedBy: input.promotedBy,
     },
   });

--- a/packages/console/prisma/migrations/20260701120000_release_force_immediate/migration.sql
+++ b/packages/console/prisma/migrations/20260701120000_release_force_immediate/migration.sql
@@ -1,0 +1,3 @@
+-- Per-release emergency escalation flag: when true, devices treat this
+-- release as an immediate update on their next lifecycle event.
+ALTER TABLE "Release" ADD COLUMN "forceImmediate" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/console/prisma/schema.prisma
+++ b/packages/console/prisma/schema.prisma
@@ -207,6 +207,7 @@ model Release {
   previousBundle   Bundle?   @relation("ReleasePreviousBundle", fields: [previousBundleId], references: [id], onDelete: SetNull)
   previousBundleId String?
   channel          String?
+  forceImmediate   Boolean   @default(false)
   promotedAt       DateTime  @default(now())
   promotedBy       String?
   revertedAt       DateTime?

--- a/packages/site/app/docs/update-strategies/page.tsx
+++ b/packages/site/app/docs/update-strategies/page.tsx
@@ -3,7 +3,8 @@ import { Separator } from '@/components/ui/separator';
 
 export const metadata = {
   title: 'Update Strategies',
-  description: 'How launchPolicy, resumePolicy, and runtimePolicy combine to control when updates apply.',
+  description:
+    'How launchPolicy, resumePolicy, and runtimePolicy combine to control when updates apply.',
 };
 
 export default function UpdateStrategiesPage() {
@@ -91,18 +92,27 @@ export default function UpdateStrategiesPage() {
 
       <H3>Ship critical fixes instantly</H3>
       <P>
-        Set <Code>launchPolicy</Code> and <Code>resumePolicy</Code> to <Code>immediate</Code> as
-        well. Devices apply a fix as soon as they check — even mid-session on resume. Trade-off:
-        users can see the app reload while they&apos;re using it, so reserve this for cases where
-        landing the fix fast matters more than a seamless reload.
+        Mark the release as <strong>force immediate</strong> — in the dashboard&apos;s release
+        dialog or with <Code>otakit release --force-immediate</Code>. The flag is baked into the
+        signed manifest, and devices on <Code>shadow</Code> or <Code>apply-staged</Code> policies
+        escalate that one release to the immediate behavior: download, apply, and reload on their
+        next check. No app rebuild, no config change.
+      </P>
+      <P>
+        Bounds: it is &quot;immediate on the next event/check&quot;, not push — delivery is bounded
+        by lifecycle events and <Code>checkInterval</Code>. Policies set to <Code>off</Code> never
+        fetch a manifest, so they never see the flag, and the trial/rollback safety net still
+        applies. The reload can land mid-session, so reserve it for broken releases, not routine
+        rollouts. (Compiling <Code>immediate</Code> policies into the app remains an option when you
+        want this behavior for every release.)
       </P>
 
       <H3>Update quietly, reload only with consent</H3>
       <P>
         Set <Code>launchPolicy</Code> and <Code>resumePolicy</Code> to <Code>shadow</Code>. Bundles
-        stage in the background and nothing ever activates on its own — call{' '}
-        <Code>apply()</Code> yourself, for example from a &quot;restart to update&quot; banner once
-        a staged bundle shows up in <Code>getState()</Code>.
+        stage in the background and nothing ever activates on its own — call <Code>apply()</Code>{' '}
+        yourself, for example from a &quot;restart to update&quot; banner once a staged bundle shows
+        up in <Code>getState()</Code>.
       </P>
 
       <H3>Full manual control</H3>

--- a/packages/site/public/llms.txt
+++ b/packages/site/public/llms.txt
@@ -1204,7 +1204,9 @@ OtaKit has one set of four policy values and three settings that decide when eac
 
 #### Ship critical fixes instantly
 
-Set `launchPolicy` and `resumePolicy` to `immediate` as well. Devices apply a fix as soon as they check — even mid-session on resume. Trade-off: users can see the app reload while they're using it, so reserve this for cases where landing the fix fast matters more than a seamless reload.
+Mark the release as force immediate — in the dashboard's release dialog or with `otakit release --force-immediate`. The flag is baked into the signed manifest, and devices on `shadow` or `apply-staged` policies escalate that one release to the immediate behavior: download, apply, and reload on their next check. No app rebuild, no config change.
+
+Bounds: it is "immediate on the next event/check", not push — delivery is bounded by lifecycle events and `checkInterval`. Policies set to `off` never fetch a manifest, so they never see the flag, and the trial/rollback safety net still applies. The reload can land mid-session, so reserve it for broken releases, not routine rollouts. (Compiling `immediate` policies into the app remains an option when you want this behavior for every release.)
 
 #### Update quietly, reload only with consent
 


### PR DESCRIPTION
## What

Implements plan 06: one signed boolean on a release. When a release (or a revert) is marked **force immediate**, devices on `shadow`/`apply-staged` policies escalate that release to the immediate flow — download, apply, reload — on their next lifecycle event. Covers the "we shipped a bad release" emergency without the full server-controlled-strategy rework.

**Stacked on #5** (`feat/manifest-payload-v2`) — populates the `forceImmediate` payload field that PR reserved.

## Where

- **DB**: `Release.forceImmediate Boolean @default(false)` + migration (`20260701120000_release_force_immediate`)
- **API**: releases POST accepts `forceImmediate` (400 on non-boolean); revert POST optionally applies it to the release that becomes current before the lane manifest re-sync; both include it in responses (GET list too)
- **Manifest**: baked per release and covered by the signature
- **Console UI**: "Force immediate update" checkbox in the release and revert dialogs; "Rollout: Force immediate" row in the channel-chip detail
- **CLI**: `--force-immediate` on `release` and `upload`; `[force-immediate]` marker in `releases` output
- **Plugin (iOS + Android)**: flag threaded through `DownloadResolution`; shadow/apply-staged automatic branches call `requireApplyStaged(reload)` when the staged release is forced. `off` never fetches so never sees the flag; manual JS APIs unchanged; `checkInterval` throttle unchanged; trial/rollback unchanged; `LatestVersion.forceImmediate` exposed to JS
- **Docs**: plugin README section + update-strategies guide ("Ship critical fixes instantly" now leads with the flag)

## Verification

- `typecheck`: console, cli, plugin, site ✅
- `build`: cli, plugin ✅
- `xcrun swiftc -parse` on `UpdaterPlugin.swift` ✅
- prettier on all changed files (incl. Java via prettier-plugin-java) ✅
- `node scripts/generate-llms-txt.mjs` ✅ (regenerated llms.txt included)
- ⚠️ Migration SQL is hand-written (no local DB); not executed. It's a single additive `ALTER TABLE ... ADD COLUMN ... DEFAULT false`.

## Notes

- Revert semantics per plan: no implicit force on revert; the reverted-to release keeps its own flag unless the revert body overrides it.
- `alreadyStaged`-at-launch under `apply-staged` applies at startup before any fetch, then classifies as `noUpdate` — no double reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)