### PR TITLE
feat: opt-in delta updates (per-file content-addressed objects) — plan 01

### DIFF
--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/BundleStore.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/BundleStore.java
@@ -26,6 +26,7 @@ final class BundleStore {
   private final Context context;
   private final SharedPreferences prefs;
   private final File bundlesDirectory;
+  private final File filesCacheDirectory;
   private final String builtinVersion;
   private final String nativeBuild;
   private final String appRuntimeVersion;
@@ -46,6 +47,16 @@ final class BundleStore {
       //noinspection ResultOfMethodCallIgnored
       bundlesDirectory.mkdirs();
     }
+    this.filesCacheDirectory = new File(this.context.getFilesDir(), "otakit_files");
+    if (!filesCacheDirectory.exists()) {
+      //noinspection ResultOfMethodCallIgnored
+      filesCacheDirectory.mkdirs();
+    }
+  }
+
+  /** Content-addressed file cache for the deltas strategy ({@code otakit_files/<sha256>}). */
+  File getFilesCacheDirectory() {
+    return filesCacheDirectory;
   }
 
   String getNativeBuild() {

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/DeltaAssembler.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/DeltaAssembler.java
@@ -1,0 +1,389 @@
+package com.otakit.updater;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Assembles a delta-strategy bundle from per-file content-addressed objects.
+ *
+ * <p>The content cache ({@code otakit_files/<sha256>}) is the device-side
+ * state: previous bundles and the builtin seed populate it, and assembling a
+ * new bundle downloads only the cache misses. Mirrors DeltaAssembler.swift.
+ */
+final class DeltaAssembler {
+
+  // Mirror ZipUtils' extraction limits.
+  private static final int MAX_FILES = 10_000;
+  private static final long MAX_TOTAL_SIZE = 500_000_000L; // 500 MB
+  private static final int MAX_PATH_LENGTH = 512;
+
+  private static final String BUILTIN_SEED_MARKER_NAME = "builtin_seed.json";
+
+  private final File cacheDirectory;
+  private final boolean allowInsecureUrls;
+
+  DeltaAssembler(File cacheDirectory, boolean allowInsecureUrls) {
+    this.cacheDirectory = cacheDirectory;
+    this.allowInsecureUrls = allowInsecureUrls;
+  }
+
+  // ── Canonical file list ─────────────────────────────────────────────
+
+  /**
+   * Canonical file list hash — must match the server's computeFilesHash
+   * (console/lib/delta-files.ts) and the iOS mirror byte-for-byte: entries
+   * sorted by UTF-8 bytes of path, lines {@code <path>:<sha256 lowercase>},
+   * joined with "\n", hashed with SHA-256 (hex).
+   */
+  static String computeFilesHash(List<ManifestClient.ManifestFileEntry> entries) throws Exception {
+    List<ManifestClient.ManifestFileEntry> sorted = new ArrayList<>(entries);
+    sorted.sort((lhs, rhs) -> {
+      byte[] lhsBytes = lhs.path.getBytes(StandardCharsets.UTF_8);
+      byte[] rhsBytes = rhs.path.getBytes(StandardCharsets.UTF_8);
+      int limit = Math.min(lhsBytes.length, rhsBytes.length);
+      for (int index = 0; index < limit; index++) {
+        int lhsByte = lhsBytes[index] & 0xff;
+        int rhsByte = rhsBytes[index] & 0xff;
+        if (lhsByte != rhsByte) {
+          return Integer.compare(lhsByte, rhsByte);
+        }
+      }
+      return Integer.compare(lhsBytes.length, rhsBytes.length);
+    });
+
+    StringBuilder canonical = new StringBuilder();
+    for (int index = 0; index < sorted.size(); index++) {
+      if (index > 0) {
+        canonical.append('\n');
+      }
+      ManifestClient.ManifestFileEntry entry = sorted.get(index);
+      canonical.append(entry.path).append(':').append(entry.sha256.toLowerCase());
+    }
+
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    byte[] hash = digest.digest(canonical.toString().getBytes(StandardCharsets.UTF_8));
+    StringBuilder builder = new StringBuilder();
+    for (byte b : hash) {
+      builder.append(String.format("%02x", b));
+    }
+    return builder.toString();
+  }
+
+  // ── Validation ──────────────────────────────────────────────────────
+
+  private static boolean isValidEntryPath(String path) {
+    if (path == null || path.isEmpty() || path.length() > MAX_PATH_LENGTH) {
+      return false;
+    }
+    if (path.startsWith("/") || path.contains("\\")) {
+      return false;
+    }
+    for (String segment : path.split("/", -1)) {
+      if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+        return false;
+      }
+    }
+    for (int index = 0; index < path.length(); index++) {
+      char c = path.charAt(index);
+      if (c < 0x20 || c == 0x7f) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void validate(List<ManifestClient.ManifestFileEntry> entries, String expectedFilesHash)
+    throws Exception {
+    if (entries == null || entries.isEmpty()) {
+      throw new IllegalStateException("Delta manifest has no files");
+    }
+    if (entries.size() > MAX_FILES) {
+      throw new IllegalStateException("Delta manifest exceeds file count limit: " + entries.size());
+    }
+
+    Set<String> seenPaths = new HashSet<>();
+    long totalSize = 0;
+    for (ManifestClient.ManifestFileEntry entry : entries) {
+      if (!isValidEntryPath(entry.path)) {
+        throw new IllegalStateException("Invalid file path in delta manifest: " + entry.path);
+      }
+      if (!seenPaths.add(entry.path)) {
+        throw new IllegalStateException("Duplicate file path in delta manifest: " + entry.path);
+      }
+      if (entry.size > 0) {
+        totalSize += entry.size;
+        if (totalSize > MAX_TOTAL_SIZE) {
+          throw new IllegalStateException("Delta manifest exceeds total size limit: " + totalSize);
+        }
+      }
+    }
+
+    if (!seenPaths.contains("index.html")) {
+      throw new IllegalStateException("Delta bundle does not contain index.html");
+    }
+
+    // The signed manifest sha256 is the filesHash; recomputing it here is what
+    // extends signature coverage to every (path, sha256) pair.
+    if (!computeFilesHash(entries).equals(expectedFilesHash.toLowerCase())) {
+      throw new IllegalStateException("Delta file list does not match the signed filesHash");
+    }
+  }
+
+  // ── Cache ───────────────────────────────────────────────────────────
+
+  private File cachePath(String sha256) {
+    return new File(cacheDirectory, sha256.toLowerCase());
+  }
+
+  private void ensureCached(ManifestClient.ManifestFileEntry entry, Context context)
+    throws Exception {
+    File cached = cachePath(entry.sha256);
+    if (cached.exists()) {
+      return;
+    }
+
+    URL url = new URL(entry.url);
+    ManifestClient.requireHTTPS(url, allowInsecureUrls);
+
+    File temporary = File.createTempFile("otakit-file-", ".tmp", context.getCacheDir());
+    try {
+      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+      try {
+        connection.setRequestMethod("GET");
+        connection.setConnectTimeout(15_000);
+        connection.setReadTimeout(60_000);
+
+        int status = connection.getResponseCode();
+        if (status < 200 || status >= 300) {
+          throw new IllegalStateException("File download failed with HTTP " + status);
+        }
+
+        try (
+          InputStream input = connection.getInputStream();
+          FileOutputStream output = new FileOutputStream(temporary)
+        ) {
+          byte[] buffer = new byte[8192];
+          int read;
+          while ((read = input.read(buffer)) > 0) {
+            output.write(buffer, 0, read);
+          }
+        }
+      } finally {
+        connection.disconnect();
+      }
+
+      if (!HashUtils.verify(temporary, entry.sha256)) {
+        throw new IllegalStateException("Downloaded file hash mismatch: " + entry.path);
+      }
+
+      if (!cached.exists()) {
+        copyFile(temporary, cached);
+      }
+    } finally {
+      //noinspection ResultOfMethodCallIgnored
+      temporary.delete();
+    }
+  }
+
+  // ── Assembly ────────────────────────────────────────────────────────
+
+  /**
+   * Fill cache misses and lay out the bundle directory from the cache.
+   * Entries must be validated first.
+   */
+  void assemble(List<ManifestClient.ManifestFileEntry> entries, File destination, Context context)
+    throws Exception {
+    if (destination.exists()) {
+      deleteRecursively(destination);
+    }
+    if (!destination.mkdirs()) {
+      throw new IllegalStateException("Cannot create assembly directory");
+    }
+
+    String destinationPrefix = destination.getCanonicalPath() + File.separator;
+
+    for (ManifestClient.ManifestFileEntry entry : entries) {
+      ensureCached(entry, context);
+
+      File target = new File(destination, entry.path);
+      // Defense in depth alongside isValidEntryPath (mirrors ZipUtils).
+      if (!target.getCanonicalPath().startsWith(destinationPrefix)) {
+        throw new IllegalStateException("Invalid file path in delta manifest: " + entry.path);
+      }
+      File parent = target.getParentFile();
+      if (parent != null && !parent.exists() && !parent.mkdirs()) {
+        throw new IllegalStateException("Cannot create parent: " + parent.getAbsolutePath());
+      }
+      copyFile(cachePath(entry.sha256), target);
+    }
+  }
+
+  // ── Builtin seeding ─────────────────────────────────────────────────
+
+  private File builtinSeedFile() {
+    return new File(cacheDirectory, BUILTIN_SEED_MARKER_NAME);
+  }
+
+  private JSONObject readBuiltinSeed() {
+    try (FileInputStream input = new FileInputStream(builtinSeedFile())) {
+      java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+      byte[] buffer = new byte[8192];
+      int read;
+      while ((read = input.read(buffer)) > 0) {
+        out.write(buffer, 0, read);
+      }
+      return new JSONObject(new String(out.toByteArray(), StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * Hash the store-build web assets into the cache once per native build, so
+   * the first OTA only downloads what changed relative to the binary.
+   * Best-effort: failures only cost extra downloads.
+   */
+  void seedFromBuiltinIfNeeded(Context context, String assetPath, String nativeBuild) {
+    JSONObject seed = readBuiltinSeed();
+    if (seed != null && nativeBuild.equals(seed.optString("nativeBuild"))) {
+      return;
+    }
+
+    List<String> hashes = new ArrayList<>();
+    try {
+      seedAssetDirectory(context.getAssets(), assetPath, hashes, context);
+    } catch (Exception e) {
+      android.util.Log.w("OtaKit", "builtin delta seed failed", e);
+      return;
+    }
+
+    try {
+      JSONObject newSeed = new JSONObject();
+      newSeed.put("nativeBuild", nativeBuild);
+      newSeed.put("hashes", new JSONArray(hashes));
+      try (FileOutputStream output = new FileOutputStream(builtinSeedFile())) {
+        output.write(newSeed.toString().getBytes(StandardCharsets.UTF_8));
+      }
+    } catch (Exception e) {
+      android.util.Log.w("OtaKit", "builtin delta seed marker write failed", e);
+    }
+  }
+
+  private void seedAssetDirectory(
+    AssetManager assets,
+    String assetPath,
+    List<String> hashes,
+    Context context
+  ) throws Exception {
+    String[] children = assets.list(assetPath);
+    if (children == null || children.length == 0) {
+      // Leaf: treat as a file.
+      String sha256;
+      try (InputStream input = assets.open(assetPath)) {
+        sha256 = HashUtils.sha256(input);
+      }
+      File cached = cachePath(sha256);
+      if (!cached.exists()) {
+        try (
+          InputStream input = assets.open(assetPath);
+          FileOutputStream output = new FileOutputStream(cached)
+        ) {
+          byte[] buffer = new byte[8192];
+          int read;
+          while ((read = input.read(buffer)) > 0) {
+            output.write(buffer, 0, read);
+          }
+        }
+      }
+      hashes.add(sha256);
+      return;
+    }
+    for (String child : children) {
+      seedAssetDirectory(assets, assetPath + "/" + child, hashes, context);
+    }
+  }
+
+  // ── Eviction ────────────────────────────────────────────────────────
+
+  /**
+   * Remove cache entries not referenced by any live bundle and not part of
+   * the builtin seed. Best-effort.
+   */
+  void pruneCache(Set<String> referencedHashes) {
+    Set<String> keep = new HashSet<>();
+    for (String hash : referencedHashes) {
+      keep.add(hash.toLowerCase());
+    }
+    JSONObject seed = readBuiltinSeed();
+    if (seed != null) {
+      JSONArray seedHashes = seed.optJSONArray("hashes");
+      if (seedHashes != null) {
+        for (int index = 0; index < seedHashes.length(); index++) {
+          String hash = seedHashes.optString(index, null);
+          if (hash != null) {
+            keep.add(hash.toLowerCase());
+          }
+        }
+      }
+    }
+
+    File[] items = cacheDirectory.listFiles();
+    if (items == null) {
+      return;
+    }
+    for (File item : items) {
+      String name = item.getName();
+      if (BUILTIN_SEED_MARKER_NAME.equals(name)) {
+        continue;
+      }
+      if (!keep.contains(name.toLowerCase())) {
+        //noinspection ResultOfMethodCallIgnored
+        item.delete();
+      }
+    }
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────
+
+  private static void copyFile(File source, File destination) throws Exception {
+    try (
+      FileInputStream input = new FileInputStream(source);
+      FileOutputStream output = new FileOutputStream(destination)
+    ) {
+      byte[] buffer = new byte[8192];
+      int read;
+      while ((read = input.read(buffer)) > 0) {
+        output.write(buffer, 0, read);
+      }
+    }
+  }
+
+  private static void deleteRecursively(File target) {
+    if (!target.exists()) {
+      return;
+    }
+    File[] children = target.listFiles();
+    if (children != null) {
+      for (File child : children) {
+        deleteRecursively(child);
+      }
+    }
+    //noinspection ResultOfMethodCallIgnored
+    target.delete();
+  }
+}

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/DeltaAssembler.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/DeltaAssembler.java
@@ -104,6 +104,11 @@ final class DeltaAssembler {
         return false;
       }
     }
+    // Metadata files the plugin writes into the bundle directory; an app
+    // file with the same root-level name would be overwritten.
+    if ("bundle.json".equals(path) || "otakit_files.json".equals(path)) {
+      return false;
+    }
     return true;
   }
 
@@ -192,7 +197,10 @@ final class DeltaAssembler {
       }
 
       if (!cached.exists()) {
-        copyFile(temporary, cached);
+        // Write via temp + rename so process death mid-copy can never leave
+        // a truncated file at a content-addressed path (exists() implies
+        // fully-written, hash-verified content).
+        atomicCopyIntoCache(temporary, cached);
       }
     } finally {
       //noinspection ResultOfMethodCallIgnored
@@ -299,9 +307,10 @@ final class DeltaAssembler {
       }
       File cached = cachePath(sha256);
       if (!cached.exists()) {
+        File staging = new File(cacheDirectory, ".tmp-" + java.util.UUID.randomUUID());
         try (
           InputStream input = assets.open(assetPath);
-          FileOutputStream output = new FileOutputStream(cached)
+          FileOutputStream output = new FileOutputStream(staging)
         ) {
           byte[] buffer = new byte[8192];
           int read;
@@ -309,6 +318,7 @@ final class DeltaAssembler {
             output.write(buffer, 0, read);
           }
         }
+        renameIntoCache(staging, cached);
       }
       hashes.add(sha256);
       return;
@@ -348,7 +358,7 @@ final class DeltaAssembler {
     }
     for (File item : items) {
       String name = item.getName();
-      if (BUILTIN_SEED_MARKER_NAME.equals(name)) {
+      if (BUILTIN_SEED_MARKER_NAME.equals(name) || name.startsWith(".tmp-")) {
         continue;
       }
       if (!keep.contains(name.toLowerCase())) {
@@ -359,6 +369,23 @@ final class DeltaAssembler {
   }
 
   // ── Helpers ─────────────────────────────────────────────────────────
+
+  private void atomicCopyIntoCache(File source, File destination) throws Exception {
+    File staging = new File(cacheDirectory, ".tmp-" + java.util.UUID.randomUUID());
+    copyFile(source, staging);
+    renameIntoCache(staging, destination);
+  }
+
+  private static void renameIntoCache(File staging, File destination) throws Exception {
+    if (!staging.renameTo(destination)) {
+      //noinspection ResultOfMethodCallIgnored
+      staging.delete();
+      // A concurrent writer may have won the rename; that's fine.
+      if (!destination.exists()) {
+        throw new IllegalStateException("Failed to move cached file into place: " + destination);
+      }
+    }
+  }
 
   private static void copyFile(File source, File destination) throws Exception {
     try (

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/HashUtils.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/HashUtils.java
@@ -2,11 +2,27 @@ package com.otakit.updater;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.security.MessageDigest;
 
 final class HashUtils {
 
   private HashUtils() {}
+
+  static String sha256(InputStream input) throws Exception {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    byte[] buffer = new byte[1024 * 1024];
+    int read;
+    while ((read = input.read(buffer)) > 0) {
+      digest.update(buffer, 0, read);
+    }
+    byte[] hash = digest.digest();
+    StringBuilder builder = new StringBuilder();
+    for (byte b : hash) {
+      builder.append(String.format("%02x", b));
+    }
+    return builder.toString();
+  }
 
   static String sha256(File file) throws Exception {
     MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/ManifestClient.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/ManifestClient.java
@@ -45,10 +45,27 @@ final class ManifestClient {
     }
   }
 
+  static final class ManifestFileEntry {
+
+    final String path;
+    final String sha256;
+    final long size;
+    final String url;
+
+    ManifestFileEntry(String path, String sha256, long size, String url) {
+      this.path = path;
+      this.sha256 = sha256;
+      this.size = size;
+      this.url = url;
+    }
+  }
+
   static final class LatestManifest {
 
     final String version;
+    /** Bundle zip URL. Present for the zip strategy; null for deltas. */
     final String url;
+    /** Zip hash for the zip strategy; canonical filesHash for deltas. */
     final String sha256;
     final int size;
     final String runtimeVersion;
@@ -56,6 +73,8 @@ final class ManifestClient {
     final String strategy;
     final boolean forceImmediate;
     final ManifestEncryption encryption;
+    /** Per-file entries for the deltas strategy; null for zip. */
+    final java.util.List<ManifestFileEntry> files;
 
     LatestManifest(
       String version,
@@ -66,7 +85,8 @@ final class ManifestClient {
       String releaseId,
       String strategy,
       boolean forceImmediate,
-      ManifestEncryption encryption
+      ManifestEncryption encryption,
+      java.util.List<ManifestFileEntry> files
     ) {
       this.version = version;
       this.url = url;
@@ -77,6 +97,7 @@ final class ManifestClient {
       this.strategy = strategy;
       this.forceImmediate = forceImmediate;
       this.encryption = encryption;
+      this.files = files;
     }
   }
 
@@ -146,7 +167,6 @@ final class ManifestClient {
       JSONObject json = new JSONObject(payload);
 
       String version = json.getString("version");
-      String downloadUrl = json.getString("url");
       String sha256 = json.getString("sha256");
       int size = json.getInt("size");
 
@@ -181,7 +201,23 @@ final class ManifestClient {
       boolean forceImmediate = json.optBoolean("forceImmediate", false);
       ManifestEncryption encryption = parseEncryption(json);
 
-      requireHTTPS(new URL(downloadUrl), allowInsecureUrls);
+      String downloadUrl = null;
+      if (json.has("url") && !json.isNull("url")) {
+        String rawUrl = json.getString("url").trim();
+        if (!rawUrl.isEmpty()) {
+          downloadUrl = rawUrl;
+        }
+      }
+
+      java.util.List<ManifestFileEntry> files = null;
+      if ("deltas".equals(strategy)) {
+        files = parseFiles(json, allowInsecureUrls);
+      } else {
+        if (downloadUrl == null) {
+          throw new IllegalStateException("Manifest response missing required url");
+        }
+        requireHTTPS(new URL(downloadUrl), allowInsecureUrls);
+      }
 
       if (manifestKeys == null || manifestKeys.isEmpty()) {
         android.util.Log.w(
@@ -221,11 +257,40 @@ final class ManifestClient {
         releaseId,
         strategy,
         forceImmediate,
-        encryption
+        encryption,
+        files
       );
     } finally {
       connection.disconnect();
     }
+  }
+
+  private static java.util.List<ManifestFileEntry> parseFiles(
+    JSONObject json,
+    boolean allowInsecureUrls
+  ) throws Exception {
+    if (!json.has("files") || json.isNull("files")) {
+      throw new IllegalStateException("Delta manifest is missing its file list");
+    }
+    org.json.JSONArray rawFiles = json.getJSONArray("files");
+    if (rawFiles.length() == 0) {
+      throw new IllegalStateException("Delta manifest has an empty file list");
+    }
+
+    java.util.List<ManifestFileEntry> entries = new java.util.ArrayList<>(rawFiles.length());
+    for (int index = 0; index < rawFiles.length(); index++) {
+      JSONObject rawFile = rawFiles.getJSONObject(index);
+      if (!rawFile.has("path") || !rawFile.has("sha256") || !rawFile.has("url")) {
+        throw new IllegalStateException("Delta manifest file entry is missing required fields");
+      }
+      String path = rawFile.getString("path");
+      String fileSha256 = rawFile.getString("sha256");
+      String fileUrl = rawFile.getString("url");
+      long fileSize = rawFile.optLong("size", -1);
+      requireHTTPS(new URL(fileUrl), allowInsecureUrls);
+      entries.add(new ManifestFileEntry(path, fileSha256, fileSize, fileUrl));
+    }
+    return entries;
   }
 
   private static ManifestEncryption parseEncryption(JSONObject json) throws Exception {

--- a/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
+++ b/packages/capacitor-plugin/android/src/main/java/com/otakit/updater/UpdaterPlugin.java
@@ -928,9 +928,12 @@ public class UpdaterPlugin extends Plugin {
   private JSObject manifestToJSObject(ManifestClient.LatestManifest latest) {
     JSObject object = new JSObject();
     object.put("version", latest.version);
-    object.put("url", latest.url);
+    if (latest.url != null) {
+      object.put("url", latest.url);
+    }
     object.put("sha256", latest.sha256);
     object.put("size", latest.size);
+    object.put("strategy", latest.strategy);
     if (latest.runtimeVersion != null) {
       object.put("runtimeVersion", latest.runtimeVersion);
     }
@@ -942,6 +945,14 @@ public class UpdaterPlugin extends Plugin {
     ManifestClient.LatestManifest latest,
     String targetChannel
   ) throws Exception {
+    if ("deltas".equals(latest.strategy)) {
+      return assembleAndStage(latest, targetChannel);
+    }
+
+    if (latest.url == null) {
+      throw new IllegalStateException("Invalid download URL from manifest");
+    }
+
     return downloadAndStage(
       new URL(latest.url),
       latest.version,
@@ -951,6 +962,151 @@ public class UpdaterPlugin extends Plugin {
       targetChannel,
       latest.releaseId
     );
+  }
+
+  private static final String BUNDLE_FILE_LIST_NAME = "otakit_files.json";
+
+  /**
+   * Deltas strategy: fill content-cache misses and assemble the bundle from
+   * the cache, then hand it to the same staging path the zip flow uses.
+   */
+  private BundleInfo assembleAndStage(ManifestClient.LatestManifest manifest, String targetChannel)
+    throws Exception {
+    // Same conservative disk-space guard as the zip path.
+    if (manifest.size > 0) {
+      long requiredSpace = (long) (manifest.size * 2.5);
+      if (getFreeDiskSpace() < requiredSpace) {
+        sendDeviceEvent(
+          "download_error",
+          manifest.version,
+          manifest.runtimeVersion,
+          targetChannel,
+          manifest.releaseId,
+          "insufficient_disk_space"
+        );
+        throw new IllegalStateException("Insufficient disk space");
+      }
+    }
+
+    File assembleDirectory = new File(
+      getContext().getCacheDir(),
+      "otakit-assemble-" + System.currentTimeMillis()
+    );
+
+    try {
+      if (manifest.files == null || manifest.files.isEmpty()) {
+        throw new IllegalStateException("Delta manifest is missing its file list");
+      }
+
+      DeltaAssembler assembler = new DeltaAssembler(
+        store.getFilesCacheDirectory(),
+        allowInsecureUrls
+      );
+      assembler.validate(manifest.files, manifest.sha256);
+      assembler.seedFromBuiltinIfNeeded(getContext(), BUILTIN_ASSET_PATH, store.getNativeBuild());
+      assembler.assemble(manifest.files, assembleDirectory, getContext());
+
+      String bundleId = buildBundleId(manifest.version, manifest.releaseId, manifest.sha256);
+      File destination = coordinator.bundleDirectory(bundleId);
+      if (destination.exists()) {
+        deleteRecursively(destination);
+      }
+      moveDirectory(assembleDirectory, destination);
+
+      // Record this bundle's content hashes for cache pruning.
+      try {
+        org.json.JSONArray hashes = new org.json.JSONArray();
+        for (ManifestClient.ManifestFileEntry entry : manifest.files) {
+          hashes.put(entry.sha256.toLowerCase());
+        }
+        try (
+          FileOutputStream output = new FileOutputStream(
+            new File(destination, BUNDLE_FILE_LIST_NAME)
+          )
+        ) {
+          output.write(hashes.toString().getBytes(StandardCharsets.UTF_8));
+        }
+      } catch (Exception ignored) {}
+
+      BundleInfo info = new BundleInfo(
+        bundleId,
+        manifest.version,
+        manifest.runtimeVersion,
+        BundleStatus.PENDING,
+        System.currentTimeMillis(),
+        manifest.sha256,
+        destination.getAbsolutePath(),
+        targetChannel,
+        manifest.releaseId
+      );
+      java.util.List<String> cleanupBundleIds = coordinator.stageDownloadedBundle(info);
+      coordinator.cleanupBundles(cleanupBundleIds);
+
+      pruneDeltaCache(assembler);
+
+      sendDeviceEvent(
+        "downloaded",
+        manifest.version,
+        manifest.runtimeVersion,
+        targetChannel,
+        manifest.releaseId,
+        null
+      );
+      return info;
+    } catch (Exception e) {
+      sendDeviceEvent(
+        "download_error",
+        manifest.version,
+        manifest.runtimeVersion,
+        targetChannel,
+        manifest.releaseId,
+        e.getMessage()
+      );
+      throw e;
+    } finally {
+      if (assembleDirectory.exists()) {
+        try {
+          deleteRecursively(assembleDirectory);
+        } catch (Exception ignored) {}
+      }
+    }
+  }
+
+  /** Keep only cache entries referenced by live bundles (plus the builtin seed). */
+  private void pruneDeltaCache(DeltaAssembler assembler) {
+    java.util.Set<String> referenced = new java.util.HashSet<>();
+    String[] liveBundleIds = new String[] {
+      store.getCurrentBundleId(),
+      store.getFallbackBundleId(),
+      store.getStagedBundleId(),
+    };
+    for (String bundleId : liveBundleIds) {
+      if (bundleId == null) {
+        continue;
+      }
+      File listFile = new File(store.bundleDirectory(bundleId), BUNDLE_FILE_LIST_NAME);
+      if (!listFile.exists()) {
+        continue;
+      }
+      try (FileInputStream input = new FileInputStream(listFile)) {
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = input.read(buffer)) > 0) {
+          out.write(buffer, 0, read);
+        }
+        org.json.JSONArray hashes = new org.json.JSONArray(
+          new String(out.toByteArray(), StandardCharsets.UTF_8)
+        );
+        for (int index = 0; index < hashes.length(); index++) {
+          String hash = hashes.optString(index, null);
+          if (hash != null) {
+            referenced.add(hash.toLowerCase());
+          }
+        }
+      } catch (Exception ignored) {}
+    }
+    assembler.pruneCache(referenced);
   }
 
   private void moveDirectory(File source, File destination) throws Exception {

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/BundleStore.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/BundleStore.swift
@@ -41,6 +41,23 @@ final class BundleStore {
     return directory
   }()
 
+  /// Content-addressed file cache for the deltas strategy (`otakit_files/<sha256>`).
+  private(set) lazy var filesCacheDirectory: URL = {
+    let appSupport = fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first!
+    let directory = appSupport.appendingPathComponent(
+      "otakit_files",
+      isDirectory: true
+    )
+    try? fileManager.createDirectory(
+      at: directory,
+      withIntermediateDirectories: true
+    )
+    return directory
+  }()
+
   var builtinVersion: String {
     Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
   }

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/DeltaAssembler.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/DeltaAssembler.swift
@@ -100,6 +100,11 @@ final class DeltaAssembler {
         return false
       }
     }
+    // Metadata files the plugin writes into the bundle directory; an app
+    // file with the same root-level name would be overwritten.
+    if path == "bundle.json" || path == "otakit_files.json" {
+      return false
+    }
     return true
   }
 
@@ -111,16 +116,18 @@ final class DeltaAssembler {
       throw DeltaAssemblerError.fileCountExceeded(entries.count)
     }
 
-    var seenPaths = Set<String>()
+    // Key on UTF-8 bytes, not String: Swift compares canonically-equivalent
+    // strings (NFC vs NFD) as equal, which would reject a manifest the
+    // server and Android both accept.
+    var seenPaths = Set<Data>()
     var totalSize: UInt64 = 0
     for entry in entries {
       guard isValidEntryPath(entry.path) else {
         throw DeltaAssemblerError.invalidPath(entry.path)
       }
-      guard !seenPaths.contains(entry.path) else {
+      guard seenPaths.insert(Data(entry.path.utf8)).inserted else {
         throw DeltaAssemblerError.duplicatePath(entry.path)
       }
-      seenPaths.insert(entry.path)
       if let size = entry.size, size > 0 {
         totalSize += UInt64(size)
         if totalSize > maxTotalSize {
@@ -129,7 +136,7 @@ final class DeltaAssembler {
       }
     }
 
-    guard seenPaths.contains("index.html") else {
+    guard seenPaths.contains(Data("index.html".utf8)) else {
       throw DeltaAssemblerError.missingIndexHtml
     }
 
@@ -170,7 +177,22 @@ final class DeltaAssembler {
     if fileManager.fileExists(atPath: destination.path) {
       return
     }
-    try fileManager.copyItem(at: temporary, to: destination)
+    // Write via temp + rename so a crash mid-copy can never leave a
+    // truncated file at a content-addressed path (exists() implies valid).
+    let staging = cacheDirectory.appendingPathComponent(
+      ".tmp-\(UUID().uuidString)",
+      isDirectory: false
+    )
+    try fileManager.copyItem(at: temporary, to: staging)
+    do {
+      try fileManager.moveItem(at: staging, to: destination)
+    } catch {
+      try? fileManager.removeItem(at: staging)
+      // A concurrent writer may have won the rename; that's fine.
+      if !fileManager.fileExists(atPath: destination.path) {
+        throw error
+      }
+    }
   }
 
   // MARK: - Assembly
@@ -250,7 +272,15 @@ final class DeltaAssembler {
       }
       let destination = cachePath(for: sha256)
       if !fileManager.fileExists(atPath: destination.path) {
-        try? fileManager.copyItem(at: item, to: destination)
+        let staging = cacheDirectory.appendingPathComponent(
+          ".tmp-\(UUID().uuidString)",
+          isDirectory: false
+        )
+        if (try? fileManager.copyItem(at: item, to: staging)) != nil {
+          if (try? fileManager.moveItem(at: staging, to: destination)) == nil {
+            try? fileManager.removeItem(at: staging)
+          }
+        }
       }
       hashes.append(sha256)
     }
@@ -275,7 +305,7 @@ final class DeltaAssembler {
       return
     }
     for item in items {
-      if item == DeltaAssembler.builtinSeedMarkerName {
+      if item == DeltaAssembler.builtinSeedMarkerName || item.hasPrefix(".tmp-") {
         continue
       }
       if !keep.contains(item.lowercased()) {

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/DeltaAssembler.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/DeltaAssembler.swift
@@ -1,0 +1,286 @@
+import CryptoKit
+import Foundation
+
+enum DeltaAssemblerError: Error, LocalizedError {
+  case missingFiles
+  case invalidPath(String)
+  case duplicatePath(String)
+  case fileCountExceeded(Int)
+  case totalSizeExceeded(UInt64)
+  case filesHashMismatch
+  case fileHashMismatch(String)
+  case missingIndexHtml
+  case invalidFileURL(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .missingFiles:
+      return "Delta manifest has no files"
+    case let .invalidPath(path):
+      return "Invalid file path in delta manifest: \(path)"
+    case let .duplicatePath(path):
+      return "Duplicate file path in delta manifest: \(path)"
+    case let .fileCountExceeded(count):
+      return "Delta manifest exceeds file count limit: \(count)"
+    case let .totalSizeExceeded(size):
+      return "Delta manifest exceeds total size limit: \(size)"
+    case .filesHashMismatch:
+      return "Delta file list does not match the signed filesHash"
+    case let .fileHashMismatch(path):
+      return "Downloaded file hash mismatch: \(path)"
+    case .missingIndexHtml:
+      return "Delta bundle does not contain index.html"
+    case let .invalidFileURL(url):
+      return "Invalid file download URL: \(url)"
+    }
+  }
+}
+
+/// Assembles a delta-strategy bundle from per-file content-addressed objects.
+///
+/// The content cache (`otakit_files/<sha256>`) is the device-side state:
+/// previous bundles and the builtin seed populate it, and assembling a new
+/// bundle downloads only the cache misses.
+final class DeltaAssembler {
+  // Mirror ZipUtils' extraction limits.
+  private let maxFiles = 10_000
+  private let maxTotalSize: UInt64 = 500_000_000 // 500 MB
+
+  private let cacheDirectory: URL
+  private let downloader: Downloader
+  private let fileManager = FileManager.default
+
+  private static let builtinSeedMarkerName = "builtin_seed.json"
+
+  init(cacheDirectory: URL, downloader: Downloader) {
+    self.cacheDirectory = cacheDirectory
+    self.downloader = downloader
+  }
+
+  // MARK: - Canonical file list
+
+  /// Canonical file list hash — must match the server's computeFilesHash
+  /// (console/lib/delta-files.ts) and the Android mirror byte-for-byte:
+  /// entries sorted by UTF-8 bytes of path, lines "<path>:<sha256 lowercase>",
+  /// joined with "\n", hashed with SHA-256 (hex).
+  static func computeFilesHash(_ entries: [ManifestFileEntry]) -> String {
+    let sorted = entries.sorted { lhs, rhs in
+      let lhsBytes = Array(lhs.path.utf8)
+      let rhsBytes = Array(rhs.path.utf8)
+      for index in 0..<min(lhsBytes.count, rhsBytes.count) {
+        if lhsBytes[index] != rhsBytes[index] {
+          return lhsBytes[index] < rhsBytes[index]
+        }
+      }
+      return lhsBytes.count < rhsBytes.count
+    }
+    let canonical = sorted
+      .map { "\($0.path):\($0.sha256.lowercased())" }
+      .joined(separator: "\n")
+    let digest = SHA256.hash(data: Data(canonical.utf8))
+    return digest.map { String(format: "%02x", $0) }.joined()
+  }
+
+  // MARK: - Validation
+
+  private func isValidEntryPath(_ path: String) -> Bool {
+    if path.isEmpty || path.count > 512 {
+      return false
+    }
+    if path.hasPrefix("/") || path.contains("\\") {
+      return false
+    }
+    for segment in path.split(separator: "/", omittingEmptySubsequences: false) {
+      if segment.isEmpty || segment == "." || segment == ".." {
+        return false
+      }
+    }
+    for scalar in path.unicodeScalars {
+      if scalar.value < 0x20 || scalar.value == 0x7f {
+        return false
+      }
+    }
+    return true
+  }
+
+  func validate(_ entries: [ManifestFileEntry], expectedFilesHash: String) throws {
+    guard !entries.isEmpty else {
+      throw DeltaAssemblerError.missingFiles
+    }
+    guard entries.count <= maxFiles else {
+      throw DeltaAssemblerError.fileCountExceeded(entries.count)
+    }
+
+    var seenPaths = Set<String>()
+    var totalSize: UInt64 = 0
+    for entry in entries {
+      guard isValidEntryPath(entry.path) else {
+        throw DeltaAssemblerError.invalidPath(entry.path)
+      }
+      guard !seenPaths.contains(entry.path) else {
+        throw DeltaAssemblerError.duplicatePath(entry.path)
+      }
+      seenPaths.insert(entry.path)
+      if let size = entry.size, size > 0 {
+        totalSize += UInt64(size)
+        if totalSize > maxTotalSize {
+          throw DeltaAssemblerError.totalSizeExceeded(totalSize)
+        }
+      }
+    }
+
+    guard seenPaths.contains("index.html") else {
+      throw DeltaAssemblerError.missingIndexHtml
+    }
+
+    // The signed manifest sha256 is the filesHash; recomputing it here is what
+    // extends signature coverage to every (path, sha256) pair.
+    guard DeltaAssembler.computeFilesHash(entries) == expectedFilesHash.lowercased() else {
+      throw DeltaAssemblerError.filesHashMismatch
+    }
+  }
+
+  // MARK: - Cache
+
+  private func cachePath(for sha256: String) -> URL {
+    cacheDirectory.appendingPathComponent(sha256.lowercased(), isDirectory: false)
+  }
+
+  private func isCached(_ sha256: String) -> Bool {
+    fileManager.fileExists(atPath: cachePath(for: sha256).path)
+  }
+
+  private func ensureCached(_ entry: ManifestFileEntry) async throws {
+    if isCached(entry.sha256) {
+      return
+    }
+
+    guard let url = URL(string: entry.url) else {
+      throw DeltaAssemblerError.invalidFileURL(entry.url)
+    }
+
+    let temporary = try await downloader.download(from: url)
+    defer { try? fileManager.removeItem(at: temporary) }
+
+    guard try HashUtils.verify(fileURL: temporary, expectedSha256: entry.sha256) else {
+      throw DeltaAssemblerError.fileHashMismatch(entry.path)
+    }
+
+    let destination = cachePath(for: entry.sha256)
+    if fileManager.fileExists(atPath: destination.path) {
+      return
+    }
+    try fileManager.copyItem(at: temporary, to: destination)
+  }
+
+  // MARK: - Assembly
+
+  /// Fill cache misses and lay out the bundle directory from the cache.
+  /// `destination` must be an empty/absent directory; entries must be
+  /// validated first.
+  func assemble(entries: [ManifestFileEntry], into destination: URL) async throws {
+    if fileManager.fileExists(atPath: destination.path) {
+      try fileManager.removeItem(at: destination)
+    }
+    try fileManager.createDirectory(at: destination, withIntermediateDirectories: true)
+
+    let destinationPrefix = destination.standardizedFileURL.path.hasSuffix("/")
+      ? destination.standardizedFileURL.path
+      : destination.standardizedFileURL.path + "/"
+
+    for entry in entries {
+      try await ensureCached(entry)
+
+      let target = destination.appendingPathComponent(entry.path, isDirectory: false)
+      // Defense in depth alongside isValidEntryPath (mirrors ZipUtils).
+      guard target.standardizedFileURL.path.hasPrefix(destinationPrefix) else {
+        throw DeltaAssemblerError.invalidPath(entry.path)
+      }
+      let parent = target.deletingLastPathComponent()
+      try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+      try fileManager.copyItem(at: cachePath(for: entry.sha256), to: target)
+    }
+  }
+
+  // MARK: - Builtin seeding
+
+  private struct BuiltinSeed: Codable {
+    let nativeBuild: String
+    let hashes: [String]
+  }
+
+  private var builtinSeedURL: URL {
+    cacheDirectory.appendingPathComponent(DeltaAssembler.builtinSeedMarkerName, isDirectory: false)
+  }
+
+  private func readBuiltinSeed() -> BuiltinSeed? {
+    guard let data = try? Data(contentsOf: builtinSeedURL) else {
+      return nil
+    }
+    return try? JSONDecoder().decode(BuiltinSeed.self, from: data)
+  }
+
+  /// Hash the store-build web assets into the cache once per native build, so
+  /// the first OTA only downloads what changed relative to the binary.
+  /// Best-effort: failures only cost extra downloads.
+  func seedFromBuiltinIfNeeded(builtinDirectory: URL, nativeBuild: String) {
+    if let seed = readBuiltinSeed(), seed.nativeBuild == nativeBuild {
+      return
+    }
+
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: builtinDirectory.path, isDirectory: &isDirectory),
+          isDirectory.boolValue else {
+      return
+    }
+
+    var hashes: [String] = []
+    let enumerator = fileManager.enumerator(
+      at: builtinDirectory,
+      includingPropertiesForKeys: [.isRegularFileKey],
+      options: [.skipsHiddenFiles]
+    )
+    while let item = enumerator?.nextObject() as? URL {
+      guard let isRegular = try? item.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile,
+            isRegular == true else {
+        continue
+      }
+      guard let sha256 = try? HashUtils.sha256(fileURL: item) else {
+        continue
+      }
+      let destination = cachePath(for: sha256)
+      if !fileManager.fileExists(atPath: destination.path) {
+        try? fileManager.copyItem(at: item, to: destination)
+      }
+      hashes.append(sha256)
+    }
+
+    let seed = BuiltinSeed(nativeBuild: nativeBuild, hashes: hashes)
+    if let data = try? JSONEncoder().encode(seed) {
+      try? data.write(to: builtinSeedURL, options: .atomic)
+    }
+  }
+
+  // MARK: - Eviction
+
+  /// Remove cache entries not referenced by any live bundle and not part of
+  /// the builtin seed. Best-effort.
+  func pruneCache(referencedHashes: Set<String>) {
+    var keep = Set(referencedHashes.map { $0.lowercased() })
+    if let seed = readBuiltinSeed() {
+      keep.formUnion(seed.hashes.map { $0.lowercased() })
+    }
+
+    guard let items = try? fileManager.contentsOfDirectory(atPath: cacheDirectory.path) else {
+      return
+    }
+    for item in items {
+      if item == DeltaAssembler.builtinSeedMarkerName {
+        continue
+      }
+      if !keep.contains(item.lowercased()) {
+        try? fileManager.removeItem(at: cacheDirectory.appendingPathComponent(item))
+      }
+    }
+  }
+}

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/ManifestClient.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/ManifestClient.swift
@@ -11,9 +11,18 @@ struct ManifestEncryption {
   let nonce: String
 }
 
+struct ManifestFileEntry {
+  let path: String
+  let sha256: String
+  let size: Int?
+  let url: String
+}
+
 struct LatestManifest {
   let version: String
-  let url: String
+  /// Bundle zip URL. Present for the zip strategy; nil for deltas.
+  let url: String?
+  /// Zip hash for the zip strategy; canonical filesHash for deltas.
   let sha256: String
   let size: Int
   let runtimeVersion: String?
@@ -21,6 +30,8 @@ struct LatestManifest {
   let strategy: String
   let forceImmediate: Bool
   let encryption: ManifestEncryption?
+  /// Per-file entries for the deltas strategy; nil for zip.
+  let files: [ManifestFileEntry]?
 }
 
 struct ManifestSignature {
@@ -105,7 +116,6 @@ enum ManifestClient {
     guard
       let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
       let version = object["version"] as? String,
-      let downloadUrl = object["url"] as? String,
       let sha256 = object["sha256"] as? String,
       let size = object["size"] as? Int
     else {
@@ -129,10 +139,17 @@ enum ManifestClient {
     let forceImmediate = object["forceImmediate"] as? Bool ?? false
     let encryption = try parseEncryption(object["encryption"])
 
-    guard let dlURL = URL(string: downloadUrl) else {
-      throw ManifestClientError.invalidURL
+    let downloadUrl = (object["url"] as? String)?.nilIfEmpty
+    var files: [ManifestFileEntry]?
+
+    if strategy == "deltas" {
+      files = try parseFiles(object["files"], allowInsecureUrls: allowInsecureUrls)
+    } else {
+      guard let downloadUrl, let dlURL = URL(string: downloadUrl) else {
+        throw ManifestClientError.invalidResponse
+      }
+      try requireHTTPS(url: dlURL, allowInsecure: allowInsecureUrls)
     }
-    try requireHTTPS(url: dlURL, allowInsecure: allowInsecureUrls)
 
     if manifestKeys.isEmpty {
       print("[OtaKit] WARNING: No manifest signing keys configured — signature verification is disabled for this request.")
@@ -167,8 +184,39 @@ enum ManifestClient {
       releaseId: releaseId,
       strategy: strategy,
       forceImmediate: forceImmediate,
-      encryption: encryption
+      encryption: encryption,
+      files: files
     )
+  }
+
+  private static func parseFiles(
+    _ rawValue: Any?,
+    allowInsecureUrls: Bool
+  ) throws -> [ManifestFileEntry] {
+    guard let rawFiles = rawValue as? [[String: Any]], !rawFiles.isEmpty else {
+      throw ManifestClientError.invalidResponse
+    }
+
+    var entries: [ManifestFileEntry] = []
+    entries.reserveCapacity(rawFiles.count)
+    for rawFile in rawFiles {
+      guard let path = rawFile["path"] as? String,
+            let sha256 = rawFile["sha256"] as? String,
+            let fileUrl = rawFile["url"] as? String,
+            let parsedUrl = URL(string: fileUrl) else {
+        throw ManifestClientError.invalidResponse
+      }
+      try requireHTTPS(url: parsedUrl, allowInsecure: allowInsecureUrls)
+      entries.append(
+        ManifestFileEntry(
+          path: path,
+          sha256: sha256,
+          size: rawFile["size"] as? Int,
+          url: fileUrl
+        )
+      )
+    }
+    return entries
   }
 
   private static func parseEncryption(_ rawValue: Any?) throws -> ManifestEncryption? {

--- a/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
+++ b/packages/capacitor-plugin/ios/Sources/UpdaterPlugin/UpdaterPlugin.swift
@@ -855,10 +855,13 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
   ) -> [String: Any] {
     var payload: [String: Any] = [
       "version": latest.version,
-      "url": latest.url,
       "sha256": latest.sha256,
       "size": latest.size,
+      "strategy": latest.strategy,
     ]
+    if let url = latest.url {
+      payload["url"] = url
+    }
     if let runtimeVersion = latest.runtimeVersion {
       payload["runtimeVersion"] = runtimeVersion
     }
@@ -870,7 +873,11 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
     _ manifest: LatestManifest,
     targetChannel: String?
   ) async throws -> BundleInfo {
-    guard let url = URL(string: manifest.url) else {
+    if manifest.strategy == "deltas" {
+      return try await assembleAndStage(manifest: manifest, targetChannel: targetChannel)
+    }
+
+    guard let urlString = manifest.url, let url = URL(string: urlString) else {
       throw NSError(
         domain: "OtaKit",
         code: 1,
@@ -887,6 +894,142 @@ public class UpdaterPlugin: CAPPlugin, CAPBridgedPlugin {
       channel: targetChannel,
       releaseId: manifest.releaseId
     )
+  }
+
+  private static let bundleFileListName = "otakit_files.json"
+
+  /// Deltas strategy: fill content-cache misses and assemble the bundle from
+  /// the cache, then hand it to the same staging path the zip flow uses.
+  private func assembleAndStage(
+    manifest: LatestManifest,
+    targetChannel: String?
+  ) async throws -> BundleInfo {
+    // Same conservative disk-space guard as the zip path.
+    let requiredSpace = Int64(Double(manifest.size) * 2.5)
+    if getFreeDiskSpace() < requiredSpace {
+      sendDeviceEvent(
+        action: .downloadError,
+        bundleVersion: manifest.version,
+        runtimeVersion: manifest.runtimeVersion,
+        channel: targetChannel,
+        releaseId: manifest.releaseId,
+        detail: "insufficient_disk_space"
+      )
+      throw NSError(
+        domain: "OtaKit",
+        code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Insufficient disk space"]
+      )
+    }
+
+    let assembleDirectory = fileManager.temporaryDirectory
+      .appendingPathComponent("otakit-assemble-\(UUID().uuidString)", isDirectory: true)
+    defer {
+      try? fileManager.removeItem(at: assembleDirectory)
+    }
+
+    do {
+      guard let files = manifest.files, !files.isEmpty else {
+        throw NSError(
+          domain: "OtaKit",
+          code: 1,
+          userInfo: [NSLocalizedDescriptionKey: "Delta manifest is missing its file list"]
+        )
+      }
+
+      let assembler = DeltaAssembler(
+        cacheDirectory: store.filesCacheDirectory,
+        downloader: downloader
+      )
+      try assembler.validate(files, expectedFilesHash: manifest.sha256)
+
+      if let builtinDirectory = Bundle.main.resourceURL?
+        .appendingPathComponent("public", isDirectory: true) {
+        assembler.seedFromBuiltinIfNeeded(
+          builtinDirectory: builtinDirectory,
+          nativeBuild: coordinator.nativeBuild
+        )
+      }
+
+      try await assembler.assemble(entries: files, into: assembleDirectory)
+
+      let bundleId = buildBundleId(
+        version: manifest.version,
+        releaseId: manifest.releaseId,
+        sha256: manifest.sha256
+      )
+      let destination = coordinator.bundleDirectory(for: bundleId)
+      if fileManager.fileExists(atPath: destination.path) {
+        try fileManager.removeItem(at: destination)
+      }
+      try fileManager.moveItem(at: assembleDirectory, to: destination)
+
+      // Record this bundle's content hashes for cache pruning.
+      let hashes = files.map { $0.sha256.lowercased() }
+      if let data = try? JSONSerialization.data(withJSONObject: hashes) {
+        try? data.write(
+          to: destination.appendingPathComponent(UpdaterPlugin.bundleFileListName),
+          options: .atomic
+        )
+      }
+
+      let info = BundleInfo(
+        id: bundleId,
+        version: manifest.version,
+        runtimeVersion: manifest.runtimeVersion,
+        status: .pending,
+        downloadedAt: Date(),
+        sha256: manifest.sha256,
+        path: destination.path,
+        channel: targetChannel,
+        releaseId: manifest.releaseId
+      )
+
+      let cleanupBundleIds = try coordinator.stageDownloadedBundle(info)
+      coordinator.cleanupBundles(cleanupBundleIds)
+
+      pruneDeltaCache(assembler: assembler)
+
+      sendDeviceEvent(
+        action: .downloaded,
+        bundleVersion: manifest.version,
+        runtimeVersion: manifest.runtimeVersion,
+        channel: targetChannel,
+        releaseId: manifest.releaseId
+      )
+      return info
+    } catch {
+      sendDeviceEvent(
+        action: .downloadError,
+        bundleVersion: manifest.version,
+        runtimeVersion: manifest.runtimeVersion,
+        channel: targetChannel,
+        releaseId: manifest.releaseId,
+        detail: error.localizedDescription
+      )
+      throw error
+    }
+  }
+
+  /// Keep only cache entries referenced by live bundles (plus the builtin seed).
+  private func pruneDeltaCache(assembler: DeltaAssembler) {
+    var referenced = Set<String>()
+    let liveBundleIds = [
+      store.getCurrentBundleId(),
+      store.getFallbackBundleId(),
+      store.getStagedBundleId(),
+    ]
+    for bundleId in liveBundleIds {
+      guard let bundleId else { continue }
+      let listURL = store.bundleDirectory(for: bundleId)
+        .appendingPathComponent(UpdaterPlugin.bundleFileListName)
+      guard let data = try? Data(contentsOf: listURL),
+            let hashes = try? JSONSerialization.jsonObject(with: data) as? [String] else {
+        continue
+      }
+      referenced.formUnion(hashes.map { $0.lowercased() })
+    }
+    assembler.pruneCache(referencedHashes: referenced)
   }
 
   private func pruneIncompatibleBundles() {

--- a/packages/capacitor-plugin/src/definitions.ts
+++ b/packages/capacitor-plugin/src/definitions.ts
@@ -38,14 +38,16 @@ export interface LatestVersion {
   version: string;
   /** Native compatibility lane for this update. */
   runtimeVersion?: string;
-  /** Download URL */
-  url: string;
-  /** SHA-256 checksum */
+  /** Bundle download URL. Present for the 'zip' strategy; absent for 'deltas'. */
+  url?: string;
+  /** SHA-256 checksum: the zip hash for 'zip', the canonical filesHash for 'deltas'. */
   sha256: string;
-  /** Bundle size in bytes */
+  /** Bundle size in bytes (total decompressed size for 'deltas') */
   size: number;
   /** Release history ID associated with this manifest */
   releaseId: string;
+  /** Update strategy this manifest was published with. Defaults to 'zip'. */
+  strategy?: 'zip' | 'deltas';
 }
 
 export interface OtaKitState {

--- a/packages/cli/src/commands/upload.ts
+++ b/packages/cli/src/commands/upload.ts
@@ -14,7 +14,19 @@ type UploadOptions = {
   version?: string;
   strictVersion?: boolean;
   release?: string | boolean;
+  strategy?: string;
 };
+
+function resolveStrategy(
+  flagValue: string | undefined,
+  configValue: 'zip' | 'deltas' | undefined,
+): 'zip' | 'deltas' {
+  const raw = flagValue?.trim().toLowerCase();
+  if (raw !== undefined && raw !== 'zip' && raw !== 'deltas') {
+    throw new Error(`--strategy must be "zip" or "deltas" (got "${flagValue}")`);
+  }
+  return (raw as 'zip' | 'deltas' | undefined) ?? configValue ?? 'zip';
+}
 
 function resolveReleaseChannel(
   releaseOption: string | boolean | undefined,
@@ -38,6 +50,10 @@ export const uploadCommand = new Command('upload')
   .option('--version <version>', 'Version string (default: OTAKIT_VERSION, then auto-generated)')
   .option('--strict-version', 'Require explicit version (--version or OTAKIT_VERSION)')
   .option('--release [channel]', 'Release after upload (base channel if omitted)')
+  .option(
+    '--strategy <strategy>',
+    'Upload strategy: "zip" (single archive, default) or "deltas" (per-file objects)',
+  )
   .action(async (path: string | undefined, options: UploadOptions) => {
     await runCommand(async () => {
       const config = await requireConfig({
@@ -59,8 +75,11 @@ export const uploadCommand = new Command('upload')
       }
 
       const releaseChannel = resolveReleaseChannel(options.release);
+      const strategy = resolveStrategy(options.strategy, config.updateStrategy);
 
-      const spinner = ora('Creating zip archive...').start();
+      const spinner = ora(
+        strategy === 'deltas' ? 'Hashing bundle files...' : 'Creating zip archive...',
+      ).start();
 
       const bundle = await (async () => {
         try {
@@ -70,6 +89,7 @@ export const uploadCommand = new Command('upload')
             version,
             runtimeVersion: config.runtimeVersion,
             releaseChannel,
+            strategy,
             onStatus: (message) => {
               spinner.text = message;
             },

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -8,6 +8,7 @@ export interface Bundle {
   sha256: string;
   size: number;
   runtimeVersion?: string | null;
+  strategy?: string;
   createdAt: string;
 }
 
@@ -15,6 +16,19 @@ export interface UploadInitResponse {
   uploadId: string;
   presignedUrl: string;
   storageKey: string;
+  expiresAt: string;
+}
+
+export interface DeltaFileDescriptor {
+  path: string;
+  sha256: string;
+  size: number;
+}
+
+export interface DeltaUploadInitResponse {
+  uploadId: string;
+  filesHash: string;
+  uploads: { sha256: string; presignedUrl: string }[];
   expiresAt: string;
 }
 
@@ -106,6 +120,24 @@ export class ApiClient {
 
   async finalizeUpload(options: { uploadId: string }): Promise<Bundle> {
     return this.fetch(this.appPath('/bundles/finalize'), {
+      method: 'POST',
+      body: JSON.stringify(options),
+    });
+  }
+
+  async initiateDeltaUpload(options: {
+    version: string;
+    runtimeVersion?: string;
+    files: DeltaFileDescriptor[];
+  }): Promise<DeltaUploadInitResponse> {
+    return this.fetch(this.appPath('/bundles/initiate-delta'), {
+      method: 'POST',
+      body: JSON.stringify(options),
+    });
+  }
+
+  async finalizeDeltaUpload(options: { uploadId: string }): Promise<Bundle> {
+    return this.fetch(this.appPath('/bundles/finalize-delta'), {
       method: 'POST',
       body: JSON.stringify(options),
     });

--- a/packages/cli/src/lib/api.ts
+++ b/packages/cli/src/lib/api.ts
@@ -23,6 +23,8 @@ export interface DeltaFileDescriptor {
   path: string;
   sha256: string;
   size: number;
+  /** Base64 MD5, pinned into the presigned PUT as Content-MD5. */
+  md5: string;
 }
 
 export interface DeltaUploadInitResponse {

--- a/packages/cli/src/lib/capacitor-config.ts
+++ b/packages/cli/src/lib/capacitor-config.ts
@@ -13,11 +13,14 @@ export const CAPACITOR_CONFIG_FILE_NAMES = [
 
 type UnknownRecord = Record<string, unknown>;
 
+export type UpdateStrategy = 'zip' | 'deltas';
+
 export interface CapacitorProjectConfig {
   configPath: string;
   appId?: string;
   channel?: string;
   runtimeVersion?: string;
+  updateStrategy?: UpdateStrategy;
   configuredServerUrl?: string;
   outputDir?: string;
 }
@@ -176,6 +179,10 @@ function extractProjectConfig(configPath: string, rawConfig: unknown): Capacitor
       otaKitConfig?.runtimeVersion,
       `${configPath}.plugins.OtaKit.runtimeVersion`,
     ),
+    updateStrategy: readOptionalUpdateStrategy(
+      otaKitConfig?.updateStrategy,
+      `${configPath}.plugins.OtaKit.updateStrategy`,
+    ),
     configuredServerUrl: readOptionalString(
       otaKitConfig?.serverUrl,
       `${configPath}.plugins.OtaKit.serverUrl`,
@@ -192,6 +199,17 @@ function asOptionalRecord(value: unknown, fieldPath: string): UnknownRecord | un
     throw new Error(`${fieldPath} must be an object.`);
   }
   return value;
+}
+
+function readOptionalUpdateStrategy(value: unknown, fieldPath: string): UpdateStrategy | undefined {
+  const raw = readOptionalString(value, fieldPath);
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (raw !== 'zip' && raw !== 'deltas') {
+    throw new Error(`${fieldPath} must be "zip" or "deltas".`);
+  }
+  return raw;
 }
 
 function readOptionalString(value: unknown, fieldPath: string): string | undefined {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -34,6 +34,7 @@ export interface ProjectConfig {
   appId?: string;
   channel?: string;
   runtimeVersion?: string;
+  updateStrategy?: 'zip' | 'deltas';
   configuredServerUrl?: string;
   outputDir?: string;
 }
@@ -42,6 +43,7 @@ export interface CliConfig extends ServerAuthConfig {
   appId: string;
   channel?: string;
   runtimeVersion?: string;
+  updateStrategy?: 'zip' | 'deltas';
   outputDir?: string;
 }
 
@@ -64,6 +66,7 @@ export interface ConfigResolveSnapshot {
   outputDir: ResolvedValue<string | null>;
   channel: ResolvedValue<string | null>;
   runtimeVersion: ResolvedValue<string | null>;
+  updateStrategy: ResolvedValue<'zip' | 'deltas' | null>;
   authToken: ResolvedValue<string | null>;
   authSource: AuthSource | null;
 }
@@ -169,6 +172,7 @@ export async function readProjectConfig(
     appId: projectConfig.appId,
     channel: projectConfig.channel,
     runtimeVersion: projectConfig.runtimeVersion,
+    updateStrategy: projectConfig.updateStrategy,
     configuredServerUrl: projectConfig.configuredServerUrl
       ? parseServerUrl(projectConfig.configuredServerUrl, cwd)
       : undefined,
@@ -251,6 +255,10 @@ export async function resolveConfigSnapshot(
   const runtimeVersionValue = runtimeVersionFromConfig ?? null;
   const runtimeVersionSource: ConfigValueSource = runtimeVersionFromConfig ? 'config' : 'none';
 
+  const updateStrategyFromConfig = projectConfig?.updateStrategy;
+  const updateStrategyValue = updateStrategyFromConfig ?? null;
+  const updateStrategySource: ConfigValueSource = updateStrategyFromConfig ? 'config' : 'none';
+
   const outputDirFromFlag = toNonEmptyString(options?.outputDir);
   const outputDirFromEnv = resolveEnvOutputDir();
   const outputDirFromConfig = projectConfig?.outputDir;
@@ -305,6 +313,10 @@ export async function resolveConfigSnapshot(
       value: runtimeVersionValue,
       source: runtimeVersionSource,
     },
+    updateStrategy: {
+      value: updateStrategyValue,
+      source: updateStrategySource,
+    },
     authToken: {
       value: authTokenValue,
       source: authTokenSource,
@@ -339,6 +351,7 @@ export async function requireConfig(options?: ConfigResolveOptions): Promise<Cli
     appId: snapshot.appId.value,
     channel: snapshot.channel.value ?? undefined,
     runtimeVersion: snapshot.runtimeVersion.value ?? undefined,
+    updateStrategy: snapshot.updateStrategy.value ?? undefined,
     outputDir: snapshot.outputDir.value ?? undefined,
     serverUrl: snapshot.serverUrl.value,
     authToken: snapshot.authToken.value,

--- a/packages/cli/src/lib/hash.ts
+++ b/packages/cli/src/lib/hash.ts
@@ -16,6 +16,26 @@ export async function hashFile(filePath: string): Promise<string> {
 }
 
 /**
+ * Calculate SHA-256 (hex) and MD5 (base64) of a file in one read.
+ * The MD5 is pinned into presigned PUTs as Content-MD5 so storage rejects
+ * an upload whose bytes don't match what was hashed.
+ */
+export async function hashFileWithMd5(filePath: string): Promise<{ sha256: string; md5: string }> {
+  return new Promise((resolve, reject) => {
+    const sha256 = createHash('sha256');
+    const md5 = createHash('md5');
+    const stream = createReadStream(filePath);
+
+    stream.on('data', (data) => {
+      sha256.update(data);
+      md5.update(data);
+    });
+    stream.on('end', () => resolve({ sha256: sha256.digest('hex'), md5: md5.digest('base64') }));
+    stream.on('error', reject);
+  });
+}
+
+/**
  * Calculate SHA-256 hash of a buffer
  */
 export function hashBuffer(buffer: Buffer): string {

--- a/packages/cli/src/lib/upload-workflow.ts
+++ b/packages/cli/src/lib/upload-workflow.ts
@@ -1,11 +1,11 @@
-import { createReadStream, readFileSync, unlinkSync } from 'node:fs';
+import { createReadStream, readFileSync, readdirSync, unlinkSync } from 'node:fs';
 import { stat } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, posix, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import type { ApiClient, Bundle } from './api.js';
+import type { ApiClient, Bundle, DeltaFileDescriptor } from './api.js';
 import { CliError } from './errors.js';
 import { hashFile } from './hash.js';
 import { getCliUserAgent } from './version.js';
@@ -132,6 +132,7 @@ export type UploadWorkflowOptions = {
   version: string;
   runtimeVersion?: string;
   releaseChannel?: string | null;
+  strategy?: 'zip' | 'deltas';
   onStatus?: (message: string) => void;
 };
 
@@ -143,6 +144,10 @@ export type UploadWorkflowResult = {
 export async function runUploadWorkflow(
   options: UploadWorkflowOptions,
 ): Promise<UploadWorkflowResult> {
+  if (options.strategy === 'deltas') {
+    return runDeltaUploadWorkflow(options);
+  }
+
   const { api, sourcePath, version, runtimeVersion, releaseChannel, onStatus } = options;
 
   validateBundleDirectory(sourcePath);
@@ -198,6 +203,155 @@ export async function runUploadWorkflow(
     process.off('SIGINT', cleanup);
     await removeFileIfExists(tempZipPath);
   }
+}
+
+/**
+ * Walk a bundle directory into relative posix file descriptors.
+ * Mirrors the zip walker's rules: symlinks are rejected, empty files included.
+ */
+export async function collectDeltaFiles(sourceDirectory: string): Promise<DeltaFileDescriptor[]> {
+  const files: DeltaFileDescriptor[] = [];
+
+  const walk = async (relativePath: string): Promise<void> => {
+    const currentPath = join(sourceDirectory, relativePath);
+    const entries = readdirSync(currentPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const nextRelativePath = relativePath ? join(relativePath, entry.name) : entry.name;
+      const absolutePath = join(sourceDirectory, nextRelativePath);
+      const posixPath = nextRelativePath.split('\\').join(posix.sep);
+
+      if (entry.isSymbolicLink()) {
+        throw new CliError(
+          [
+            `Unsupported symlink in bundle output: ${posixPath}`,
+            'Remove symlinks from the web build output before uploading.',
+          ].join('\n'),
+        );
+      }
+      if (entry.isDirectory()) {
+        await walk(nextRelativePath);
+        continue;
+      }
+      if (entry.isFile()) {
+        const fileStat = await stat(absolutePath);
+        files.push({
+          path: posixPath,
+          sha256: await hashFile(absolutePath),
+          size: fileStat.size,
+        });
+      }
+    }
+  };
+
+  await walk('');
+  return files;
+}
+
+async function uploadDeltaFileToPresignedUrl(
+  filePath: string,
+  size: number,
+  presignedUrl: string,
+): Promise<void> {
+  const body = createReadStream(filePath);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 300_000);
+
+  const requestOptions: RequestInit & { duplex?: 'half' } = {
+    method: 'PUT',
+    body,
+    signal: controller.signal,
+    headers: {
+      // Must match the headers pinned into the presigned signature
+      // (console/lib/storage.ts::createPresignedFileUpload).
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': String(size),
+      'Cache-Control': 'public, max-age=31536000, immutable',
+      'User-Agent': getCliUserAgent(),
+    },
+    duplex: 'half',
+  };
+
+  try {
+    const response = await fetch(presignedUrl, requestOptions);
+    if (!response.ok) {
+      const message = await response.text();
+      throw new CliError(`File upload failed (${response.status}): ${message || 'unknown error'}`);
+    }
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+const DELTA_UPLOAD_CONCURRENCY = 8;
+
+async function runDeltaUploadWorkflow(
+  options: UploadWorkflowOptions,
+): Promise<UploadWorkflowResult> {
+  const { api, sourcePath, version, runtimeVersion, releaseChannel, onStatus } = options;
+
+  validateBundleDirectory(sourcePath);
+
+  onStatus?.('Hashing bundle files...');
+  const files = await collectDeltaFiles(sourcePath);
+  if (files.length === 0) {
+    throw new CliError(`No files found in ${sourcePath}`);
+  }
+
+  onStatus?.(`Requesting delta upload for ${files.length} files...`);
+  const initiated = await api.initiateDeltaUpload({
+    version,
+    runtimeVersion,
+    files,
+  });
+
+  const expiresAt = new Date(initiated.expiresAt);
+  if (expiresAt.getTime() - Date.now() < 60_000) {
+    throw new CliError('Presigned upload URLs have expired or are about to expire. Please retry.');
+  }
+
+  const pathByHash = new Map<string, { path: string; size: number }>();
+  for (const file of files) {
+    if (!pathByHash.has(file.sha256)) {
+      pathByHash.set(file.sha256, { path: file.path, size: file.size });
+    }
+  }
+
+  const uploads = initiated.uploads;
+  if (uploads.length > 0) {
+    onStatus?.(`Uploading ${uploads.length} new files (${files.length} total)...`);
+    let uploaded = 0;
+    for (let index = 0; index < uploads.length; index += DELTA_UPLOAD_CONCURRENCY) {
+      const chunk = uploads.slice(index, index + DELTA_UPLOAD_CONCURRENCY);
+      await Promise.all(
+        chunk.map(async (upload) => {
+          const source = pathByHash.get(upload.sha256);
+          if (!source) {
+            throw new CliError(`Server requested unknown file hash: ${upload.sha256}`);
+          }
+          await uploadDeltaFileToPresignedUrl(
+            join(sourcePath, source.path),
+            source.size,
+            upload.presignedUrl,
+          );
+          uploaded += 1;
+          onStatus?.(`Uploading new files: ${uploaded}/${uploads.length}`);
+        }),
+      );
+    }
+  } else {
+    onStatus?.('All files already uploaded (content reuse) — skipping upload.');
+  }
+
+  onStatus?.('Finalizing...');
+  const bundle = await api.finalizeDeltaUpload({ uploadId: initiated.uploadId });
+
+  if (releaseChannel !== undefined) {
+    onStatus?.(`Releasing to ${releaseChannel ?? 'base channel'}...`);
+    await api.release(releaseChannel, bundle.id);
+  }
+
+  return { bundle, releaseChannel };
 }
 
 function validateVersion(value: string | undefined, label: string): string | null {

--- a/packages/cli/src/lib/upload-workflow.ts
+++ b/packages/cli/src/lib/upload-workflow.ts
@@ -7,11 +7,12 @@ import { tmpdir } from 'node:os';
 
 import type { ApiClient, Bundle, DeltaFileDescriptor } from './api.js';
 import { CliError } from './errors.js';
-import { hashFile } from './hash.js';
+import { hashFile, hashFileWithMd5 } from './hash.js';
 import { getCliUserAgent } from './version.js';
 import { createZip, removeFileIfExists, validateBundleDirectory } from './zip.js';
 
 const MAX_VERSION_LENGTH = 64;
+const MAX_DELTA_FILES = 5000; // mirrors the server cap (console/lib/delta-files.ts)
 
 const COMMIT_ENV_KEYS = [
   'OTAKIT_COMMIT_SHA',
@@ -235,10 +236,12 @@ export async function collectDeltaFiles(sourceDirectory: string): Promise<DeltaF
       }
       if (entry.isFile()) {
         const fileStat = await stat(absolutePath);
+        const hashes = await hashFileWithMd5(absolutePath);
         files.push({
           path: posixPath,
-          sha256: await hashFile(absolutePath),
+          sha256: hashes.sha256,
           size: fileStat.size,
+          md5: hashes.md5,
         });
       }
     }
@@ -251,6 +254,7 @@ export async function collectDeltaFiles(sourceDirectory: string): Promise<DeltaF
 async function uploadDeltaFileToPresignedUrl(
   filePath: string,
   size: number,
+  md5: string,
   presignedUrl: string,
 ): Promise<void> {
   const body = createReadStream(filePath);
@@ -266,6 +270,7 @@ async function uploadDeltaFileToPresignedUrl(
       // (console/lib/storage.ts::createPresignedFileUpload).
       'Content-Type': 'application/octet-stream',
       'Content-Length': String(size),
+      'Content-MD5': md5,
       'Cache-Control': 'public, max-age=31536000, immutable',
       'User-Agent': getCliUserAgent(),
     },
@@ -297,6 +302,12 @@ async function runDeltaUploadWorkflow(
   if (files.length === 0) {
     throw new CliError(`No files found in ${sourcePath}`);
   }
+  if (files.length > MAX_DELTA_FILES) {
+    throw new CliError(
+      `Too many files for the delta strategy: ${files.length} (max ${MAX_DELTA_FILES}). ` +
+        'Consider updateStrategy: "zip" for this app.',
+    );
+  }
 
   onStatus?.(`Requesting delta upload for ${files.length} files...`);
   const initiated = await api.initiateDeltaUpload({
@@ -310,10 +321,10 @@ async function runDeltaUploadWorkflow(
     throw new CliError('Presigned upload URLs have expired or are about to expire. Please retry.');
   }
 
-  const pathByHash = new Map<string, { path: string; size: number }>();
+  const pathByHash = new Map<string, { path: string; size: number; md5: string }>();
   for (const file of files) {
     if (!pathByHash.has(file.sha256)) {
-      pathByHash.set(file.sha256, { path: file.path, size: file.size });
+      pathByHash.set(file.sha256, { path: file.path, size: file.size, md5: file.md5 });
     }
   }
 
@@ -332,6 +343,7 @@ async function runDeltaUploadWorkflow(
           await uploadDeltaFileToPresignedUrl(
             join(sourcePath, source.path),
             source.size,
+            source.md5,
             upload.presignedUrl,
           );
           uploaded += 1;

--- a/packages/console/app/api/v1/apps/[appId]/bundles/finalize-delta/route.ts
+++ b/packages/console/app/api/v1/apps/[appId]/bundles/finalize-delta/route.ts
@@ -1,0 +1,234 @@
+import { Prisma } from '@prisma/client';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { resolveOrganizationAccess } from '@/lib/organization-access';
+import { db } from '@/lib/db';
+import { computeFilesHash, type DeltaFileEntry } from '@/lib/delta-files';
+import {
+  BUNDLE_CACHE_CONTROL,
+  buildFileObjectKey,
+  putTextObject,
+  statStorageObject,
+} from '@/lib/storage';
+
+export const runtime = 'nodejs';
+
+const HEAD_CONCURRENCY = 50;
+
+function serializeBundle(bundle: {
+  id: string;
+  version: string;
+  sha256: string;
+  size: number;
+  runtimeVersion: string | null;
+  strategy: string;
+  createdAt: Date;
+}) {
+  return {
+    id: bundle.id,
+    version: bundle.version,
+    sha256: bundle.sha256,
+    size: bundle.size,
+    runtimeVersion: bundle.runtimeVersion,
+    strategy: bundle.strategy,
+    createdAt: bundle.createdAt.toISOString(),
+  };
+}
+
+const BUNDLE_SELECT = {
+  id: true,
+  version: true,
+  sha256: true,
+  size: true,
+  runtimeVersion: true,
+  strategy: true,
+  createdAt: true,
+} as const;
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ appId: string }> },
+) {
+  const routeParams = await params;
+  const appId = routeParams.appId;
+
+  const access = await resolveOrganizationAccess(request, appId);
+  if (!access.success) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const uploadId = body.uploadId;
+  if (typeof uploadId !== 'string' || uploadId.trim().length === 0) {
+    return NextResponse.json({ error: 'Missing uploadId' }, { status: 400 });
+  }
+  const normalizedUploadId = uploadId.trim();
+
+  const session = await db.uploadSession.findUnique({
+    where: { id: normalizedUploadId },
+    include: {
+      bundle: { select: BUNDLE_SELECT },
+    },
+  });
+  if (!session) {
+    return NextResponse.json({ error: 'Upload not found or expired' }, { status: 404 });
+  }
+
+  if (session.appId !== appId) {
+    return NextResponse.json({ error: 'App ID mismatch' }, { status: 403 });
+  }
+
+  if (session.strategy !== 'deltas') {
+    return NextResponse.json(
+      { error: 'Upload session is not a delta upload; use bundles/finalize' },
+      { status: 400 },
+    );
+  }
+
+  if (session.status === 'finalized') {
+    if (!session.bundle) {
+      return NextResponse.json(
+        { error: 'Upload session finalized without a bundle record' },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json(serializeBundle(session.bundle));
+  }
+
+  if (session.status === 'expired' || session.expiresAt < new Date()) {
+    if (session.status !== 'expired') {
+      await db.uploadSession.update({
+        where: { id: session.id },
+        data: { status: 'expired' },
+      });
+    }
+    return NextResponse.json({ error: 'Upload expired' }, { status: 410 });
+  }
+
+  const files = session.files as unknown as DeltaFileEntry[] | null;
+  if (!Array.isArray(files) || files.length === 0) {
+    return NextResponse.json({ error: 'Upload session is missing its file list' }, { status: 409 });
+  }
+
+  // Defense in depth: the stored list must still hash to what we promised.
+  const filesHash = computeFilesHash(files);
+  if (filesHash !== session.expectedSha256) {
+    return NextResponse.json(
+      { error: 'Upload session file list does not match its filesHash' },
+      { status: 409 },
+    );
+  }
+
+  // Verify every unique content object exists with the expected size.
+  const uniqueEntries = new Map<string, number>();
+  for (const file of files) {
+    uniqueEntries.set(file.sha256, file.size);
+  }
+  const entries = [...uniqueEntries.entries()];
+  for (let index = 0; index < entries.length; index += HEAD_CONCURRENCY) {
+    const chunk = entries.slice(index, index + HEAD_CONCURRENCY);
+    const results = await Promise.all(
+      chunk.map(async ([sha256, size]) => {
+        const stat = await statStorageObject(buildFileObjectKey(appId, sha256));
+        if (stat === null) {
+          return `Missing uploaded file object: ${sha256}`;
+        }
+        if (stat.size !== size) {
+          return `Size mismatch for ${sha256}: expected ${size} bytes, got ${stat.size} bytes`;
+        }
+        return null;
+      }),
+    );
+    const failure = results.find((result) => result !== null);
+    if (failure) {
+      return NextResponse.json({ error: failure }, { status: 400 });
+    }
+  }
+
+  // Persist the canonical file list as the bundle's storage object.
+  await putTextObject({
+    storageKey: session.storageKey,
+    body: JSON.stringify({
+      version: session.version,
+      filesHash,
+      files,
+    }),
+    contentType: 'application/json; charset=utf-8',
+    cacheControl: BUNDLE_CACHE_CONTROL,
+  });
+
+  const totalSize = session.expectedSize;
+
+  try {
+    const bundle = await db.$transaction(async (tx) => {
+      const createdBundle = await tx.bundle.create({
+        data: {
+          appId: session.appId,
+          version: session.version,
+          sha256: filesHash,
+          storageKey: session.storageKey,
+          size: totalSize,
+          runtimeVersion: session.runtimeVersion,
+          strategy: 'deltas',
+        },
+        select: BUNDLE_SELECT,
+      });
+
+      await tx.uploadSession.update({
+        where: { id: session.id },
+        data: {
+          status: 'finalized',
+          actualSize: totalSize,
+          finalizedAt: new Date(),
+          bundleId: createdBundle.id,
+        },
+      });
+
+      return createdBundle;
+    });
+
+    return NextResponse.json(serializeBundle(bundle), { status: 201 });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      const existingBundle = await db.bundle.findUnique({
+        where: {
+          appId_version: {
+            appId: session.appId,
+            version: session.version,
+          },
+        },
+        select: BUNDLE_SELECT,
+      });
+
+      if (existingBundle) {
+        await db.uploadSession
+          .update({
+            where: { id: session.id },
+            data: {
+              status: 'finalized',
+              actualSize: totalSize,
+              finalizedAt: new Date(),
+              bundleId: existingBundle.id,
+            },
+          })
+          .catch(() => undefined);
+
+        return NextResponse.json(serializeBundle(existingBundle));
+      }
+
+      return NextResponse.json(
+        { error: 'Bundle with this app/version already exists' },
+        { status: 409 },
+      );
+    }
+
+    const message = error instanceof Error ? error.message : 'Finalize failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/packages/console/app/api/v1/apps/[appId]/bundles/initiate-delta/route.ts
+++ b/packages/console/app/api/v1/apps/[appId]/bundles/initiate-delta/route.ts
@@ -114,9 +114,14 @@ export async function POST(
   const uploads: { sha256: string; presignedUrl: string }[] = [];
   for (const entry of missing) {
     if (!entry) continue;
+    const md5 = parsed.md5ByHash.get(entry.sha256);
+    if (!md5) {
+      return NextResponse.json({ error: `Missing md5 for hash ${entry.sha256}` }, { status: 400 });
+    }
     const presigned = await createPresignedFileUpload(
       buildFileObjectKey(appId, entry.sha256),
       entry.size,
+      md5,
     );
     uploads.push({ sha256: entry.sha256, presignedUrl: presigned.presignedUrl });
     expiresAt = presigned.expiresAt;

--- a/packages/console/app/api/v1/apps/[appId]/bundles/initiate-delta/route.ts
+++ b/packages/console/app/api/v1/apps/[appId]/bundles/initiate-delta/route.ts
@@ -1,0 +1,152 @@
+import crypto from 'node:crypto';
+import { Prisma } from '@prisma/client';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { resolveOrganizationAccess } from '@/lib/organization-access';
+import { db } from '@/lib/db';
+import {
+  computeFilesHash,
+  parseDeltaFiles,
+  uniqueHashes,
+  type DeltaFileEntry,
+} from '@/lib/delta-files';
+import { buildFileObjectKey, createPresignedFileUpload, statStorageObject } from '@/lib/storage';
+import {
+  isValidRuntimeVersion,
+  isValidVersion,
+  normalizeOptionalRuntimeVersion,
+} from '@/lib/validation';
+
+export const runtime = 'nodejs';
+
+const HEAD_CONCURRENCY = 50;
+
+async function mapChunked<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let index = 0; index < items.length; index += concurrency) {
+    const chunk = items.slice(index, index + concurrency);
+    results.push(...(await Promise.all(chunk.map(fn))));
+  }
+  return results;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ appId: string }> },
+) {
+  const routeParams = await params;
+  const appId = routeParams.appId;
+
+  const access = await resolveOrganizationAccess(request, appId);
+  if (!access.success) {
+    return NextResponse.json({ error: access.error }, { status: access.status });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const rawVersion = body.version;
+  if (typeof rawVersion !== 'string' || rawVersion.trim().length === 0) {
+    return NextResponse.json({ error: 'Missing version' }, { status: 400 });
+  }
+  const version = rawVersion.trim();
+  if (!isValidVersion(version)) {
+    return NextResponse.json({ error: 'Version must be 1-64 characters' }, { status: 400 });
+  }
+
+  if (
+    body.runtimeVersion !== undefined &&
+    body.runtimeVersion !== null &&
+    typeof body.runtimeVersion !== 'string'
+  ) {
+    return NextResponse.json({ error: 'runtimeVersion must be a string' }, { status: 400 });
+  }
+  const runtimeVersion = normalizeOptionalRuntimeVersion(body.runtimeVersion);
+  if (
+    typeof body.runtimeVersion === 'string' &&
+    body.runtimeVersion.trim().length > 0 &&
+    (!runtimeVersion || !isValidRuntimeVersion(runtimeVersion))
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          'runtimeVersion must be 1-64 characters using letters, numbers, dot, underscore, or dash',
+      },
+      { status: 400 },
+    );
+  }
+
+  const parsed = parseDeltaFiles(body.files);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+  const files: DeltaFileEntry[] = parsed.files;
+
+  const existing = await db.bundle.findUnique({
+    where: {
+      appId_version: { appId, version },
+    },
+    select: { id: true },
+  });
+  if (existing) {
+    return NextResponse.json({ error: `Bundle ${version} already exists` }, { status: 409 });
+  }
+
+  // Presign PUTs only for content hashes not already in storage (dedup).
+  const hashes = [...uniqueHashes(files).entries()];
+  const missing = await mapChunked(hashes, HEAD_CONCURRENCY, async ([sha256, size]) => {
+    const stat = await statStorageObject(buildFileObjectKey(appId, sha256));
+    if (stat !== null && stat.size === size) {
+      return null;
+    }
+    return { sha256, size };
+  });
+
+  let expiresAt: Date | null = null;
+  const uploads: { sha256: string; presignedUrl: string }[] = [];
+  for (const entry of missing) {
+    if (!entry) continue;
+    const presigned = await createPresignedFileUpload(
+      buildFileObjectKey(appId, entry.sha256),
+      entry.size,
+    );
+    uploads.push({ sha256: entry.sha256, presignedUrl: presigned.presignedUrl });
+    expiresAt = presigned.expiresAt;
+  }
+
+  const uploadId = crypto.randomUUID();
+  const filesHash = computeFilesHash(files);
+  const totalSize = parsed.totalSize;
+  const storageKey = `bundles/${appId}/${uploadId}.files.json`;
+  const sessionExpiresAt = expiresAt ?? new Date(Date.now() + 3600 * 1000);
+
+  await db.uploadSession.create({
+    data: {
+      id: uploadId,
+      appId,
+      version,
+      expectedSha256: filesHash,
+      expectedSize: totalSize,
+      runtimeVersion,
+      strategy: 'deltas',
+      files: files as unknown as Prisma.InputJsonValue,
+      storageKey,
+      expiresAt: sessionExpiresAt,
+    },
+  });
+
+  return NextResponse.json({
+    uploadId,
+    filesHash,
+    uploads,
+    expiresAt: sessionExpiresAt.toISOString(),
+  });
+}

--- a/packages/console/lib/delta-files.ts
+++ b/packages/console/lib/delta-files.ts
@@ -28,8 +28,15 @@ export interface DeltaFileEntry {
 }
 
 export type DeltaFilesParseResult =
-  | { ok: true; files: DeltaFileEntry[]; totalSize: number }
+  | { ok: true; files: DeltaFileEntry[]; totalSize: number; md5ByHash: Map<string, string> }
   | { ok: false; error: string };
+
+// Metadata files the plugin writes into the bundle directory; an app file
+// with the same root-level name would be overwritten at assembly time.
+const RESERVED_ROOT_FILES = new Set(['bundle.json', 'otakit_files.json']);
+
+// 16-byte MD5 as base64 (22 chars + '==').
+const MD5_BASE64_REGEX = /^[A-Za-z0-9+/]{22}==$/;
 
 function isValidDeltaPath(path: string): boolean {
   if (path.length === 0 || path.length > MAX_DELTA_PATH_LENGTH) {
@@ -42,6 +49,9 @@ function isValidDeltaPath(path: string): boolean {
     if (segment.length === 0 || segment === '.' || segment === '..') {
       return false;
     }
+  }
+  if (RESERVED_ROOT_FILES.has(path)) {
+    return false;
   }
   for (const char of path) {
     const code = char.codePointAt(0) ?? 0;
@@ -63,13 +73,14 @@ export function parseDeltaFiles(raw: unknown): DeltaFilesParseResult {
   const files: DeltaFileEntry[] = [];
   const seenPaths = new Set<string>();
   const sizeByHash = new Map<string, number>();
+  const md5ByHash = new Map<string, string>();
   let totalSize = 0;
 
   for (const entry of raw) {
     if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
       return { ok: false, error: 'Each file entry must be an object' };
     }
-    const { path, sha256, size } = entry as Record<string, unknown>;
+    const { path, sha256, size, md5 } = entry as Record<string, unknown>;
 
     if (typeof path !== 'string' || !isValidDeltaPath(path)) {
       return { ok: false, error: `Invalid file path: ${String(path)}` };
@@ -88,11 +99,20 @@ export function parseDeltaFiles(raw: unknown): DeltaFilesParseResult {
       return { ok: false, error: `Invalid size for ${path}` };
     }
 
+    if (typeof md5 !== 'string' || !MD5_BASE64_REGEX.test(md5)) {
+      return { ok: false, error: `Invalid md5 for ${path} (base64 of the 16-byte digest)` };
+    }
+
     const existingSize = sizeByHash.get(normalizedSha);
     if (existingSize !== undefined && existingSize !== size) {
       return { ok: false, error: `Conflicting sizes for content hash ${normalizedSha}` };
     }
+    const existingMd5 = md5ByHash.get(normalizedSha);
+    if (existingMd5 !== undefined && existingMd5 !== md5) {
+      return { ok: false, error: `Conflicting md5 for content hash ${normalizedSha}` };
+    }
     sizeByHash.set(normalizedSha, size);
+    md5ByHash.set(normalizedSha, md5);
 
     totalSize += size;
     files.push({ path, sha256: normalizedSha, size });
@@ -110,7 +130,7 @@ export function parseDeltaFiles(raw: unknown): DeltaFilesParseResult {
     };
   }
 
-  return { ok: true, files, totalSize };
+  return { ok: true, files, totalSize, md5ByHash };
 }
 
 function compareUtf8(a: string, b: string): number {

--- a/packages/console/lib/delta-files.ts
+++ b/packages/console/lib/delta-files.ts
@@ -1,0 +1,139 @@
+import crypto from 'node:crypto';
+
+import { getMaxBundleSize } from '@/lib/storage';
+
+/**
+ * Delta strategy file list: validation + canonical hash.
+ *
+ * The canonical file list is the signed identity of a delta bundle:
+ *   - entries sorted by path, compared as UTF-8 byte sequences
+ *   - one line per file: `<path>:<sha256 lowercase hex>`
+ *   - lines joined with "\n", no trailing newline
+ *   - filesHash = sha256 hex of the UTF-8 canonical string
+ *
+ * The native plugins (DeltaAssembler.swift / DeltaAssembler.java) recompute
+ * this exact string from the manifest's files[] and compare it against the
+ * signed manifest sha256. Any change here must change all three together.
+ */
+
+export const MAX_DELTA_FILES = 5000;
+export const MAX_DELTA_PATH_LENGTH = 512;
+
+const SHA_256_REGEX = /^[a-f0-9]{64}$/i;
+
+export interface DeltaFileEntry {
+  path: string;
+  sha256: string;
+  size: number;
+}
+
+export type DeltaFilesParseResult =
+  | { ok: true; files: DeltaFileEntry[]; totalSize: number }
+  | { ok: false; error: string };
+
+function isValidDeltaPath(path: string): boolean {
+  if (path.length === 0 || path.length > MAX_DELTA_PATH_LENGTH) {
+    return false;
+  }
+  if (path.startsWith('/') || path.includes('\\')) {
+    return false;
+  }
+  for (const segment of path.split('/')) {
+    if (segment.length === 0 || segment === '.' || segment === '..') {
+      return false;
+    }
+  }
+  for (const char of path) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function parseDeltaFiles(raw: unknown): DeltaFilesParseResult {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return { ok: false, error: 'files must be a non-empty array' };
+  }
+  if (raw.length > MAX_DELTA_FILES) {
+    return { ok: false, error: `Too many files: ${raw.length} (max ${MAX_DELTA_FILES})` };
+  }
+
+  const files: DeltaFileEntry[] = [];
+  const seenPaths = new Set<string>();
+  const sizeByHash = new Map<string, number>();
+  let totalSize = 0;
+
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      return { ok: false, error: 'Each file entry must be an object' };
+    }
+    const { path, sha256, size } = entry as Record<string, unknown>;
+
+    if (typeof path !== 'string' || !isValidDeltaPath(path)) {
+      return { ok: false, error: `Invalid file path: ${String(path)}` };
+    }
+    if (seenPaths.has(path)) {
+      return { ok: false, error: `Duplicate file path: ${path}` };
+    }
+    seenPaths.add(path);
+
+    if (typeof sha256 !== 'string' || !SHA_256_REGEX.test(sha256)) {
+      return { ok: false, error: `Invalid sha256 for ${path}` };
+    }
+    const normalizedSha = sha256.toLowerCase();
+
+    if (typeof size !== 'number' || !Number.isInteger(size) || size < 0) {
+      return { ok: false, error: `Invalid size for ${path}` };
+    }
+
+    const existingSize = sizeByHash.get(normalizedSha);
+    if (existingSize !== undefined && existingSize !== size) {
+      return { ok: false, error: `Conflicting sizes for content hash ${normalizedSha}` };
+    }
+    sizeByHash.set(normalizedSha, size);
+
+    totalSize += size;
+    files.push({ path, sha256: normalizedSha, size });
+  }
+
+  if (!seenPaths.has('index.html')) {
+    return { ok: false, error: 'files must include index.html at the bundle root' };
+  }
+
+  const maxBundleSize = getMaxBundleSize();
+  if (totalSize > maxBundleSize) {
+    return {
+      ok: false,
+      error: `Bundle too large: ${totalSize} bytes (max ${maxBundleSize} bytes)`,
+    };
+  }
+
+  return { ok: true, files, totalSize };
+}
+
+function compareUtf8(a: string, b: string): number {
+  return Buffer.compare(Buffer.from(a, 'utf-8'), Buffer.from(b, 'utf-8'));
+}
+
+export function buildCanonicalFileList(files: DeltaFileEntry[]): string {
+  return files
+    .slice()
+    .sort((a, b) => compareUtf8(a.path, b.path))
+    .map((file) => `${file.path}:${file.sha256}`)
+    .join('\n');
+}
+
+export function computeFilesHash(files: DeltaFileEntry[]): string {
+  return crypto.createHash('sha256').update(buildCanonicalFileList(files), 'utf-8').digest('hex');
+}
+
+/** Unique content hashes with their sizes (upload/verification unit). */
+export function uniqueHashes(files: DeltaFileEntry[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const file of files) {
+    map.set(file.sha256, file.size);
+  }
+  return map;
+}

--- a/packages/console/lib/manifest-files.ts
+++ b/packages/console/lib/manifest-files.ts
@@ -1,9 +1,12 @@
 import { db } from '@/lib/db';
 import { signManifest } from '@/lib/manifest-signing';
 import { purgeCdnUrls } from '@/lib/cdn-purge';
+import { type DeltaFileEntry } from '@/lib/delta-files';
 import {
+  buildFileObjectKey,
   buildPublicObjectUrl,
   deleteStorageObject,
+  getTextObject,
   listStorageKeys,
   putTextObject,
 } from '@/lib/storage';
@@ -18,6 +21,7 @@ type ManifestBundle = {
   sha256: string;
   size: number;
   runtimeVersion: string | null;
+  strategy: string;
   storageKey: string;
 };
 
@@ -57,6 +61,7 @@ export async function writeManifestFile(
   bundle: ManifestBundle,
 ): Promise<void> {
   const storageKey = buildManifestStorageKey(appId, channel, runtimeVersion);
+  const strategy = bundle.strategy === 'deltas' ? 'deltas' : 'zip';
   const signature = signManifest({
     appId,
     channel,
@@ -64,25 +69,42 @@ export async function writeManifestFile(
     sha256: bundle.sha256,
     size: bundle.size,
     runtimeVersion: bundle.runtimeVersion,
-    strategy: 'zip',
+    strategy,
     forceImmediate: false,
     encryption: null,
   });
 
+  const manifest: Record<string, unknown> = {
+    version: bundle.version,
+    sha256: bundle.sha256,
+    size: bundle.size,
+    channel,
+    runtimeVersion: bundle.runtimeVersion,
+    releaseId: release.id,
+    strategy,
+    forceImmediate: false,
+    signature,
+  };
+
+  if (strategy === 'deltas') {
+    // The bundle's storage object is the canonical file list written at
+    // finalize; expand it into per-file CDN URLs. sha256 above == filesHash.
+    const fileListRaw = await getTextObject(bundle.storageKey);
+    const fileList = JSON.parse(fileListRaw) as { files: DeltaFileEntry[] };
+    manifest.filesHash = bundle.sha256;
+    manifest.files = fileList.files.map((file) => ({
+      path: file.path,
+      sha256: file.sha256,
+      size: file.size,
+      url: buildPublicObjectUrl(buildFileObjectKey(appId, file.sha256)),
+    }));
+  } else {
+    manifest.url = buildPublicObjectUrl(bundle.storageKey);
+  }
+
   await putTextObject({
     storageKey,
-    body: JSON.stringify({
-      version: bundle.version,
-      url: buildPublicObjectUrl(bundle.storageKey),
-      sha256: bundle.sha256,
-      size: bundle.size,
-      channel,
-      runtimeVersion: bundle.runtimeVersion,
-      releaseId: release.id,
-      strategy: 'zip',
-      forceImmediate: false,
-      signature,
-    }),
+    body: JSON.stringify(manifest),
     contentType: 'application/json; charset=utf-8',
     cacheControl: MANIFEST_CACHE_CONTROL,
   });
@@ -151,6 +173,7 @@ export async function syncManifestFileForLane(
           sha256: true,
           size: true,
           runtimeVersion: true,
+          strategy: true,
           storageKey: true,
         },
       },
@@ -196,6 +219,7 @@ export async function restoreManifestFilesForApp(appId: string): Promise<void> {
           sha256: true,
           size: true,
           runtimeVersion: true,
+          strategy: true,
           storageKey: true,
         },
       },

--- a/packages/console/lib/storage.ts
+++ b/packages/console/lib/storage.ts
@@ -2,6 +2,7 @@ import {
   S3Client,
   PutObjectCommand,
   DeleteObjectCommand,
+  GetObjectCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
 } from '@aws-sdk/client-s3';
@@ -150,6 +151,86 @@ export async function inspectUploadedObject(storageKey: string): Promise<{ size:
   }
 
   return { size };
+}
+
+export function buildFileObjectKey(appId: string, sha256: string): string {
+  return `files/${appId}/${sha256}`;
+}
+
+/**
+ * Presign a PUT for a content-addressed file object (delta strategy).
+ * Content type and immutable cache header are pinned into the signature,
+ * so the uploader must send them verbatim.
+ */
+export async function createPresignedFileUpload(
+  storageKey: string,
+  size: number,
+): Promise<{ presignedUrl: string; expiresAt: Date }> {
+  const { client, bucket, presignExpiresSeconds } = getStorageConfig();
+
+  const command = new PutObjectCommand({
+    Bucket: bucket,
+    Key: storageKey,
+    ContentType: 'application/octet-stream',
+    ContentLength: size,
+    CacheControl: BUNDLE_CACHE_CONTROL,
+  });
+
+  const presignedUrl = await getSignedUrl(client, command, {
+    expiresIn: presignExpiresSeconds,
+  });
+
+  return {
+    presignedUrl,
+    expiresAt: new Date(Date.now() + presignExpiresSeconds * 1000),
+  };
+}
+
+/**
+ * HeadObject wrapper that returns null for missing keys instead of throwing.
+ */
+export async function statStorageObject(storageKey: string): Promise<{ size: number } | null> {
+  const { client, bucket } = getStorageConfig();
+  try {
+    const response = await client.send(
+      new HeadObjectCommand({
+        Bucket: bucket,
+        Key: storageKey,
+      }),
+    );
+    return { size: response.ContentLength ?? 0 };
+  } catch (error) {
+    const statusCode =
+      typeof error === 'object' &&
+      error !== null &&
+      '$metadata' in error &&
+      typeof (error as { $metadata?: { httpStatusCode?: unknown } }).$metadata?.httpStatusCode ===
+        'number'
+        ? (error as { $metadata: { httpStatusCode: number } }).$metadata.httpStatusCode
+        : undefined;
+    const errorName =
+      typeof error === 'object' && error !== null && 'name' in error
+        ? String((error as { name?: unknown }).name)
+        : '';
+    if (statusCode === 404 || errorName === 'NotFound' || errorName === 'NoSuchKey') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function getTextObject(storageKey: string): Promise<string> {
+  const { client, bucket } = getStorageConfig();
+  const response = await client.send(
+    new GetObjectCommand({
+      Bucket: bucket,
+      Key: storageKey,
+    }),
+  );
+  if (!response.Body) {
+    throw new Error(`Storage object has no body: ${storageKey}`);
+  }
+  return response.Body.transformToString('utf-8');
 }
 
 function getCdnBaseUrl(): string {

--- a/packages/console/lib/storage.ts
+++ b/packages/console/lib/storage.ts
@@ -165,14 +165,19 @@ export function buildFileObjectKey(appId: string, sha256: string): string {
 export async function createPresignedFileUpload(
   storageKey: string,
   size: number,
+  contentMd5: string,
 ): Promise<{ presignedUrl: string; expiresAt: Date }> {
   const { client, bucket, presignExpiresSeconds } = getStorageConfig();
 
+  // ContentMD5 makes storage verify the uploaded bytes: a PUT whose body
+  // doesn't match the client-declared MD5 is rejected, so a content-addressed
+  // key can never be filled with wrong-content data of the right length.
   const command = new PutObjectCommand({
     Bucket: bucket,
     Key: storageKey,
     ContentType: 'application/octet-stream',
     ContentLength: size,
+    ContentMD5: contentMd5,
     CacheControl: BUNDLE_CACHE_CONTROL,
   });
 

--- a/packages/console/prisma/migrations/20260701130000_bundle_delta_strategy/migration.sql
+++ b/packages/console/prisma/migrations/20260701130000_bundle_delta_strategy/migration.sql
@@ -1,0 +1,6 @@
+-- Bundle.strategy: 'zip' (single archive) or 'deltas' (per-file content-addressed objects)
+ALTER TABLE "Bundle" ADD COLUMN "strategy" TEXT NOT NULL DEFAULT 'zip';
+
+-- UploadSession delta support: strategy discriminator + validated file list
+ALTER TABLE "UploadSession" ADD COLUMN "strategy" TEXT NOT NULL DEFAULT 'zip';
+ALTER TABLE "UploadSession" ADD COLUMN "files" JSONB;

--- a/packages/console/prisma/schema.prisma
+++ b/packages/console/prisma/schema.prisma
@@ -188,6 +188,9 @@ model Bundle {
   storageKey         String
   size               Int
   runtimeVersion     String?
+  // 'zip' (single archive) or 'deltas' (per-file content-addressed objects;
+  // storageKey points at the canonical file-list object, sha256 = filesHash)
+  strategy           String          @default("zip")
   metadata           Json?
   createdAt          DateTime        @default(now())
   releases           Release[]       @relation("ReleaseBundle")
@@ -225,6 +228,10 @@ model UploadSession {
   expectedSize   Int
   actualSize     Int?
   runtimeVersion String?
+  // 'zip' or 'deltas'; for deltas, files holds the validated
+  // [{ path, sha256, size }] list carried from initiate to finalize
+  strategy       String              @default("zip")
+  files          Json?
   metadata       Json?
   storageKey     String
   status         UploadSessionStatus @default(initiated)


### PR DESCRIPTION
> **DRAFT — stacks on #5 (manifest payload v2).** Native paths are syntax-checked, not device-tested; review the decisions list below before promoting.

## What

Implements plan 01: an opt-in `'deltas'` update strategy alongside the unchanged `'zip'` default. Files are stored once per content hash (`files/<appId>/<sha256>`, immutable CDN cache), the manifest lists the complete target file set, and devices keep a content cache (`otakit_files/<sha256>`) so an update downloads **only the files that changed**. No version-pair diffing anywhere — correctness comes from content hashes.

Apps that don't opt in are untouched: default stays `zip`, and the zip path is byte-for-byte the same flow as before.

## How it fits together

- **Canonical file list** (the signed identity): entries sorted by UTF-8 bytes of path, lines `path:sha256`, joined `\n`; `filesHash` = SHA-256. Implemented identically in `console/lib/delta-files.ts`, `DeltaAssembler.swift`, `DeltaAssembler.java`. The manifest's signed `sha256` **is** the filesHash (payload v2 `strategy` field distinguishes semantics), and both natives **recompute it from `files[]`** — extending signature coverage to every path+hash pair.
- **Console**: new `initiate-delta` (validates list, presigns PUTs for missing hashes only — HEAD-based dedup, 50-way chunked) and `finalize-delta` (verifies every object + size, writes the canonical file-list object as the bundle's `storageKey`). Manifest emission branches on `Bundle.strategy`.
- **CLI**: `plugins.OtaKit.updateStrategy` / `--strategy deltas`; walks `webDir` (symlinks rejected — same rule as the zip walker), hashes, uploads misses with concurrency 8, finalizes.
- **Plugin (iOS + Android)**: `DeltaAssembler` validates (ZipUtils-equivalent guards: path traversal/absolute/backslash, 10k files, 500MB), fills cache misses (per-file SHA-256 verified before caching), assembles into a temp dir, then hands off to the **existing** stage/apply/trial/rollback path with the same `downloaded`/`download_error` telemetry.
- **Builtin seeding**: once per native build, the store-build web assets are hashed into the cache (iOS `Bundle.main/public`, Android assets `public`), so the *first* OTA only downloads what changed vs the binary.
- **Eviction**: after staging, cache entries not referenced by current/fallback/staged bundles (tracked via `otakit_files.json` in each bundle dir) or the builtin seed are pruned.

## Decisions made (open questions from the plan)

1. **Copy, not hardlink**, from cache into bundle dirs — simpler, no cross-volume concerns; costs disk transiently.
2. **`Bundle.sha256 = filesHash`, `storageKey` = file-list object** — keeps device identity comparison (`doesBundleMatchLatest`) and delete/GC paths working unchanged.
3. **Eviction v1** = prune-to-referenced (+ builtin seed kept permanently per native build). No size cap yet.
4. **No unreferenced-object GC server-side** (deferred, as planned).
5. **No brotli** (deferred, as planned).
6. **Manifest carries per-file `size`** (enables the pre-download disk-space guard).
7. **`otakit_files.json` + `bundle.json` live inside the served bundle dir** — follows the existing `bundle.json` precedent.
8. **Delta sessions reject the zip `finalize` endpoint** and vice-versa (strategy check).

## Verification

- `pnpm --filter` console/cli/plugin **typecheck** ✅, CLI + plugin **build** ✅ (after `db:generate`)
- `xcrun swiftc -parse` on all iOS sources ✅
- prettier (TS + Java) ✅
- **Not done**: device/E2E testing of the native assembly path, Android compile (needs SDK), migration run against a real DB. These need a pass before merge — hence draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)