### PR TITLE
Add Starter plan and grandfather existing Free usage

### DIFF
--- a/packages/console/.env.example
+++ b/packages/console/.env.example
@@ -59,8 +59,9 @@ SUPPORT_EMAIL="support@otakit.app"
 POLAR_ACCESS_TOKEN=""
 POLAR_WEBHOOK_SECRET=""
 POLAR_SERVER="sandbox"
-# Pro is the only self-serve paid plan. Free needs no product; Enterprise is
-# contact-sales (provisioned by an operator, no Polar product).
+# Starter is monthly-only. Pro has monthly and yearly products. Free needs no
+# product; Enterprise is contact-sales (provisioned by an operator).
+POLAR_PRODUCT_STARTER_MONTHLY=""
 POLAR_PRODUCT_PRO_MONTHLY=""
 POLAR_PRODUCT_PRO_YEARLY=""
 POLAR_USAGE_EVENT_NAME="otakit.download.usage.v1"

--- a/packages/console/app/api/v1/organization/billing/checkout/route.ts
+++ b/packages/console/app/api/v1/organization/billing/checkout/route.ts
@@ -12,9 +12,9 @@ import {
 
 export const runtime = 'nodejs';
 
-// Pro is the only self-serve checkout. Free is the default and Enterprise is
-// contact-sales.
-const VALID_PLAN_KEYS = new Set<string>(['pro']);
+// Starter and Pro are self-serve. Starter is intentionally monthly-only;
+// Enterprise remains contact-sales.
+const VALID_PLAN_KEYS = new Set<string>(['starter', 'pro']);
 const VALID_INTERVALS = new Set<string>(['month', 'year']);
 
 export async function POST(request: NextRequest) {
@@ -36,14 +36,28 @@ export async function POST(request: NextRequest) {
 
   const body = await request.json().catch(() => null);
   if (!body || !VALID_PLAN_KEYS.has(body.planKey)) {
-    return NextResponse.json({ error: 'Invalid planKey. Must be "pro".' }, { status: 400 });
+    return NextResponse.json(
+      { error: 'Invalid planKey. Must be "starter" or "pro".' },
+      { status: 400 },
+    );
   }
-  const interval: BillingInterval =
-    typeof body.interval === 'string' && VALID_INTERVALS.has(body.interval)
-      ? (body.interval as BillingInterval)
-      : 'month';
+  if (body.interval !== undefined && !VALID_INTERVALS.has(body.interval)) {
+    return NextResponse.json(
+      { error: 'Invalid interval. Must be "month" or "year".' },
+      { status: 400 },
+    );
+  }
+
+  const interval: BillingInterval = (body.interval as BillingInterval | undefined) ?? 'month';
 
   const planKey = body.planKey as PlanKey;
+  if (planKey === 'starter' && interval !== 'month') {
+    return NextResponse.json(
+      { error: 'Starter is available with monthly billing only.' },
+      { status: 400 },
+    );
+  }
+
   const productId = planKeyToProductId(planKey, interval);
   if (!productId) {
     return NextResponse.json({ error: 'Product not configured for this plan.' }, { status: 500 });
@@ -51,9 +65,9 @@ export async function POST(request: NextRequest) {
 
   const organization = await db.organization.findUnique({
     where: { id: ctx.organizationId },
-    select: { isActive: true, polarSubscriptionId: true },
+    select: { isActive: true },
   });
-  if (organization?.isActive && organization.polarSubscriptionId) {
+  if (organization?.isActive) {
     return NextResponse.json(
       {
         error:

--- a/packages/console/app/api/v1/organization/billing/usage/route.ts
+++ b/packages/console/app/api/v1/organization/billing/usage/route.ts
@@ -6,6 +6,7 @@ import {
   refreshOrganizationUsageSnapshot,
   updateOrganizationOverageEnabled,
 } from '@/lib/billing/usage';
+import { getOrganizationEntitlements } from '@/lib/billing/service';
 
 export const runtime = 'nodejs';
 
@@ -48,6 +49,16 @@ export async function PATCH(request: NextRequest) {
       { error: 'Invalid body. Expected { overageEnabled: boolean }.' },
       { status: 400 },
     );
+  }
+
+  if (body.overageEnabled) {
+    const entitlements = await getOrganizationEntitlements(ctx.organizationId);
+    if (!entitlements.limits.overage) {
+      return NextResponse.json(
+        { error: 'Additional usage is only available on the Pro plan.' },
+        { status: 400 },
+      );
+    }
   }
 
   const usage = await updateOrganizationOverageEnabled(ctx.organizationId, body.overageEnabled);

--- a/packages/console/app/api/v1/organization/invites/route.ts
+++ b/packages/console/app/api/v1/organization/invites/route.ts
@@ -39,7 +39,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 });
   }
 
-  // Team members are a paid entitlement — the free plan is single-seat.
+  // Team members are a Pro/Enterprise entitlement. Free and Starter are
+  // intentionally single-member workspaces.
   const entitlements = await getOrganizationEntitlements(ctx.organizationId);
   if (!entitlements.limits.teamMembers) {
     return NextResponse.json(

--- a/packages/console/app/components/PricingDialog.tsx
+++ b/packages/console/app/components/PricingDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Building2, Check, Leaf, LoaderCircle, Rocket, Star } from 'lucide-react';
+import { Building2, Check, ChevronDown, Leaf, LoaderCircle, Rocket, Star } from 'lucide-react';
 import { toast } from 'sonner';
 
 import type { ApiError } from '@/app/components/dashboard-types';
@@ -9,6 +9,12 @@ import { SUPPORT_MAILTO } from '@/lib/support';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 export type PlanKey = 'free' | 'starter' | 'pro' | 'enterprise';
 
@@ -43,7 +49,6 @@ export function PricingDialog({
   const [billingData, setBillingData] = useState<PricingDialogBillingData | null>(
     initialBillingData ?? null,
   );
-  const [interval, setInterval] = useState<BillingInterval>('year');
   const [checkingOut, setCheckingOut] = useState<'starter' | 'pro' | null>(null);
   const [openingPortal, setOpeningPortal] = useState(false);
 
@@ -154,17 +159,11 @@ export function PricingDialog({
     }
   }
 
-  const proPrice = interval === 'year' ? '$25' : '$50';
-  const proPriceNote = interval === 'year' ? 'billed $300/year — save 50%' : 'billed monthly';
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto p-8 sm:max-w-6xl">
         <DialogHeader>
-          <div className="flex items-center justify-between gap-3">
-            <DialogTitle>Pricing</DialogTitle>
-            <BillingIntervalToggle value={interval} onChange={setInterval} />
-          </div>
+          <DialogTitle>Pricing</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4">
@@ -235,8 +234,8 @@ export function PricingDialog({
 
             <PlanCard
               name="Pro"
-              price={proPrice}
-              priceNote={proPriceNote}
+              price="$25"
+              priceNote="billed $300/year — save 50%"
               subtitle="1,000,000 downloads / month*"
               features={[
                 'Everything in Free',
@@ -256,12 +255,28 @@ export function PricingDialog({
               actionIcon={Star}
               disabled={!canManageBilling}
               loading={openingPortal || checkingOut === 'pro'}
+              actionItems={
+                currentPlan !== 'pro' && !hasActiveSubscription
+                  ? [
+                      {
+                        label: 'Yearly',
+                        description: '$300/year · $25/month · save 50%',
+                        onSelect: () => void handleCheckout('pro', 'year'),
+                      },
+                      {
+                        label: 'Monthly',
+                        description: '$50/month',
+                        onSelect: () => void handleCheckout('pro', 'month'),
+                      },
+                    ]
+                  : undefined
+              }
               onAction={
                 currentPlan === 'pro'
                   ? undefined
                   : hasActiveSubscription
                     ? () => void handleManageBilling()
-                    : () => void handleCheckout('pro', interval)
+                    : undefined
               }
             />
 
@@ -308,44 +323,6 @@ export function PricingDialog({
   );
 }
 
-function BillingIntervalToggle({
-  value,
-  onChange,
-}: {
-  value: BillingInterval;
-  onChange: (value: BillingInterval) => void;
-}) {
-  return (
-    <div className="inline-flex items-center gap-1 rounded-full border border-border p-0.5 text-xs">
-      <button
-        type="button"
-        onClick={() => onChange('month')}
-        className={`rounded-full px-3 py-1 transition-colors ${
-          value === 'month' ? 'bg-foreground text-background' : 'text-muted-foreground'
-        }`}
-      >
-        Monthly
-      </button>
-      <button
-        type="button"
-        onClick={() => onChange('year')}
-        className={`flex items-center gap-1.5 rounded-full px-3 py-1 transition-colors ${
-          value === 'year' ? 'bg-foreground text-background' : 'text-muted-foreground'
-        }`}
-      >
-        Yearly
-        <span
-          className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${
-            value === 'year' ? 'bg-background/20' : 'bg-muted text-foreground'
-          }`}
-        >
-          -50%
-        </span>
-      </button>
-    </div>
-  );
-}
-
 function PlanCard({
   name,
   price,
@@ -358,6 +335,7 @@ function PlanCard({
   disabled = false,
   loading = false,
   onAction,
+  actionItems,
   highlighted = false,
   tag,
 }: {
@@ -372,6 +350,11 @@ function PlanCard({
   disabled?: boolean;
   loading?: boolean;
   onAction?: () => void;
+  actionItems?: Array<{
+    label: string;
+    description: string;
+    onSelect: () => void;
+  }>;
   highlighted?: boolean;
   tag?: string;
 }) {
@@ -409,16 +392,47 @@ function PlanCard({
       </ul>
 
       <div className="mt-auto pt-5">
-        <Button
-          className="w-full"
-          variant={current ? 'outline' : highlighted ? 'default' : 'outline'}
-          disabled={current || disabled || !onAction}
-          onClick={onAction}
-        >
-          {loading ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
-          {!loading ? <ActionIcon className="size-3.5" /> : null}
-          {actionLabel}
-        </Button>
+        {actionItems && actionItems.length > 0 ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                className="w-full"
+                variant={highlighted ? 'default' : 'outline'}
+                disabled={disabled || loading}
+              >
+                {loading ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
+                {!loading ? <ActionIcon className="size-3.5" /> : null}
+                {actionLabel}
+                <ChevronDown className="ml-auto size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-64">
+              {actionItems.map((item) => (
+                <DropdownMenuItem
+                  key={item.label}
+                  className="items-start py-2.5"
+                  onSelect={item.onSelect}
+                >
+                  <span className="flex flex-col gap-0.5">
+                    <span className="font-medium">{item.label}</span>
+                    <span className="text-xs text-muted-foreground">{item.description}</span>
+                  </span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          <Button
+            className="w-full"
+            variant={current ? 'outline' : highlighted ? 'default' : 'outline'}
+            disabled={current || disabled || !onAction}
+            onClick={onAction}
+          >
+            {loading ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
+            {!loading ? <ActionIcon className="size-3.5" /> : null}
+            {actionLabel}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/packages/console/app/components/PricingDialog.tsx
+++ b/packages/console/app/components/PricingDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Building2, Check, Leaf, LoaderCircle, Star } from 'lucide-react';
+import { Building2, Check, Leaf, LoaderCircle, Rocket, Star } from 'lucide-react';
 import { toast } from 'sonner';
 
 import type { ApiError } from '@/app/components/dashboard-types';
@@ -10,13 +10,15 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 
-export type PlanKey = 'free' | 'pro' | 'enterprise';
+export type PlanKey = 'free' | 'starter' | 'pro' | 'enterprise';
 
 type BillingInterval = 'month' | 'year';
 
 export type PricingDialogBillingData = {
   billing: {
     planKey: PlanKey;
+    isActive: boolean;
+    downloadsLimit: number;
     polarCustomerId: string | null;
   };
 };
@@ -42,7 +44,7 @@ export function PricingDialog({
     initialBillingData ?? null,
   );
   const [interval, setInterval] = useState<BillingInterval>('year');
-  const [checkingOut, setCheckingOut] = useState(false);
+  const [checkingOut, setCheckingOut] = useState<'starter' | 'pro' | null>(null);
   const [openingPortal, setOpeningPortal] = useState(false);
 
   useEffect(() => {
@@ -50,7 +52,12 @@ export function PricingDialog({
     // Re-sync only when the meaningful billing fields change, not on every parent
     // re-render that hands us a fresh object identity (which would clobber state).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialBillingData?.billing.planKey, initialBillingData?.billing.polarCustomerId]);
+  }, [
+    initialBillingData?.billing.planKey,
+    initialBillingData?.billing.isActive,
+    initialBillingData?.billing.downloadsLimit,
+    initialBillingData?.billing.polarCustomerId,
+  ]);
 
   useEffect(() => {
     if (!open) return;
@@ -102,16 +109,25 @@ export function PricingDialog({
   }, [open, billingData, onBillingDataChange]);
 
   const currentPlan = billingData?.billing.planKey ?? 'free';
-  const hasPolarCustomer = Boolean(billingData?.billing.polarCustomerId);
+  const hasActiveSubscription = Boolean(
+    billingData?.billing.isActive &&
+    (currentPlan === 'starter' || currentPlan === 'pro') &&
+    billingData.billing.polarCustomerId,
+  );
+  const hasLegacyFreeAllowance =
+    currentPlan === 'free' && (billingData?.billing.downloadsLimit ?? 0) >= 100_000;
 
-  async function handleCheckout(billingInterval: BillingInterval) {
+  async function handleCheckout(
+    planKey: Extract<PlanKey, 'starter' | 'pro'>,
+    billingInterval: BillingInterval,
+  ) {
     if (!canManageBilling) return;
-    setCheckingOut(true);
+    setCheckingOut(planKey);
     try {
       const res = await fetch('/api/v1/organization/billing/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ planKey: 'pro', interval: billingInterval }),
+        body: JSON.stringify({ planKey, interval: billingInterval }),
       });
       const data = await parseJson<ApiError & { checkoutUrl?: string }>(res);
       if (!res.ok) throw new Error(data.error ?? 'Failed to start checkout');
@@ -119,7 +135,7 @@ export function PricingDialog({
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to start checkout');
     } finally {
-      setCheckingOut(false);
+      setCheckingOut(null);
     }
   }
 
@@ -143,7 +159,7 @@ export function PricingDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-4xl p-8">
+      <DialogContent className="max-h-[85vh] overflow-y-auto p-8 sm:max-w-6xl">
         <DialogHeader>
           <div className="flex items-center justify-between gap-3">
             <DialogTitle>Pricing</DialogTitle>
@@ -152,12 +168,22 @@ export function PricingDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="grid gap-4 md:grid-cols-3">
+          {hasLegacyFreeAllowance ? (
+            <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+              Your workspace keeps its grandfathered Free allowance of 100,000 downloads per month.
+            </div>
+          ) : null}
+
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <PlanCard
               name="Free"
               price="$0"
               priceNote="forever"
-              subtitle="10,000 downloads / month*"
+              subtitle={
+                hasLegacyFreeAllowance
+                  ? '100,000 downloads / month (grandfathered)'
+                  : '5,000 downloads / month*'
+              }
               features={[
                 'Unlimited updates',
                 'Unlimited apps',
@@ -168,6 +194,43 @@ export function PricingDialog({
               actionLabel="Current plan"
               actionIcon={Leaf}
               disabled
+            />
+
+            <PlanCard
+              name="Starter"
+              price="$10"
+              priceNote="billed monthly only"
+              subtitle="100,000 downloads / month*"
+              features={[
+                'Everything in Free',
+                '20× update capacity',
+                'Single-member workspace',
+                'Hard cap — no overage',
+              ]}
+              current={currentPlan === 'starter'}
+              tag="Most popular"
+              actionLabel={
+                currentPlan === 'starter'
+                  ? 'Current plan'
+                  : hasLegacyFreeAllowance
+                    ? 'Included in your Free plan'
+                    : hasActiveSubscription
+                      ? 'Manage subscription'
+                      : 'Choose Starter'
+              }
+              actionIcon={Rocket}
+              disabled={!canManageBilling || hasLegacyFreeAllowance}
+              loading={openingPortal || checkingOut === 'starter'}
+              onAction={
+                currentPlan === 'starter'
+                  ? undefined
+                  : hasLegacyFreeAllowance
+                    ? undefined
+                    : hasActiveSubscription
+                      ? () => void handleManageBilling()
+                      : () => void handleCheckout('starter', 'month')
+              }
+              highlighted
             />
 
             <PlanCard
@@ -182,25 +245,24 @@ export function PricingDialog({
                 'Priority support',
               ]}
               current={currentPlan === 'pro'}
-              tag="Most popular"
+              tag="Best value"
               actionLabel={
                 currentPlan === 'pro'
                   ? 'Current plan'
-                  : hasPolarCustomer
+                  : hasActiveSubscription
                     ? 'Manage subscription'
                     : `Upgrade to Pro`
               }
               actionIcon={Star}
               disabled={!canManageBilling}
-              loading={openingPortal || checkingOut}
+              loading={openingPortal || checkingOut === 'pro'}
               onAction={
                 currentPlan === 'pro'
                   ? undefined
-                  : hasPolarCustomer
+                  : hasActiveSubscription
                     ? () => void handleManageBilling()
-                    : () => void handleCheckout(interval)
+                    : () => void handleCheckout('pro', interval)
               }
-              highlighted
             />
 
             <PlanCard
@@ -237,8 +299,8 @@ export function PricingDialog({
           ) : null}
 
           <p className="text-sm text-muted-foreground">
-            * Value-aligned pricing: pay for real downloaded updates. Overage on Pro is billed at
-            $50 per additional 1,000,000 downloads and can be turned off to cap spend.
+            * Value-aligned pricing: pay for real downloaded updates. Free and Starter stop at their
+            included limits. Optional Pro overage is $50 per additional 1,000,000 downloads.
           </p>
         </div>
       </DialogContent>

--- a/packages/console/app/components/SettingsDashboard.tsx
+++ b/packages/console/app/components/SettingsDashboard.tsx
@@ -120,7 +120,8 @@ export function SettingsDashboard({ initialData }: { initialData: DashboardIniti
   const [billingData, setBillingData] = useState<{
     billing: {
       planKey: PlanKey;
-      isActive?: boolean;
+      isActive: boolean;
+      downloadsLimit: number;
       polarCustomerId: string | null;
     };
   } | null>(null);
@@ -144,18 +145,27 @@ export function SettingsDashboard({ initialData }: { initialData: DashboardIniti
   const [switchingOrganizationId, setSwitchingOrganizationId] = useState<string | null>(null);
   const [signingOut, setSigningOut] = useState(false);
   const isSwitchingOrganization = switchingOrganizationId !== null;
+  const planAllowsTeamMembers =
+    billingData?.billing.planKey === 'pro' || billingData?.billing.planKey === 'enterprise';
   const pricingDialogBillingData = useMemo<PricingDialogBillingData | null>(() => {
     if (!billingData) return null;
     return {
       billing: {
         planKey: billingData.billing.planKey,
+        isActive: billingData.billing.isActive,
+        downloadsLimit: billingData.billing.downloadsLimit,
         polarCustomerId: billingData.billing.polarCustomerId,
       },
     };
     // Recompute only when the meaningful billing fields change, not on every
     // billingData object identity change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [billingData?.billing.planKey, billingData?.billing.polarCustomerId]);
+  }, [
+    billingData?.billing.planKey,
+    billingData?.billing.isActive,
+    billingData?.billing.downloadsLimit,
+    billingData?.billing.polarCustomerId,
+  ]);
 
   const loadTeamData = useCallback(async () => {
     setLoadingTeam(true);
@@ -615,9 +625,13 @@ User ID: ${initialData.user.id}`,
                         <div className="text-sm">
                           {billingData?.billing.planKey === 'pro'
                             ? 'Pro'
-                            : billingData?.billing.planKey === 'enterprise'
-                              ? 'Enterprise'
-                              : 'Free'}
+                            : billingData?.billing.planKey === 'starter'
+                              ? 'Starter'
+                              : billingData?.billing.planKey === 'enterprise'
+                                ? 'Enterprise'
+                                : billingData && billingData.billing.downloadsLimit >= 100_000
+                                  ? 'Free (grandfathered)'
+                                  : 'Free'}
                         </div>
                       </div>
                       {canManageTeam ? (
@@ -719,7 +733,7 @@ User ID: ${initialData.user.id}`,
                       </div>
                     </div>
                     {canManageTeam ? (
-                      billingData?.billing.planKey === 'free' ? (
+                      !planAllowsTeamMembers ? (
                         <Button
                           size="icon"
                           variant="ghost"
@@ -1035,10 +1049,7 @@ User ID: ${initialData.user.id}`,
           setBillingData((current) => {
             if (!current) {
               return {
-                billing: {
-                  ...nextBillingData.billing,
-                  isActive: nextBillingData.billing.planKey !== 'free',
-                },
+                billing: nextBillingData.billing,
               };
             }
             return {

--- a/packages/console/lib/auth.ts
+++ b/packages/console/lib/auth.ts
@@ -21,6 +21,9 @@ const trustedOrigins = Array.from(
     [
       process.env.BETTER_AUTH_URL,
       process.env.NEXT_PUBLIC_APP_URL,
+      // Vercel PR deployments use per-deployment hosts. Keep the wildcard
+      // scoped to this project instead of trusting every vercel.app tenant.
+      'https://otakit-console-*.vercel.app',
       appleEnabled ? 'https://appleid.apple.com' : null,
     ].filter((value): value is string => Boolean(value)),
   ),

--- a/packages/console/lib/billing/config.ts
+++ b/packages/console/lib/billing/config.ts
@@ -3,17 +3,20 @@ import { PlanKey } from '@prisma/client';
 export type PlanLimits = {
   downloads: number;
   teamMembers: boolean;
+  overage: boolean;
 };
 
 // Enterprise has no metered cap — it's a custom, operator-provisioned contract.
 // A finite-but-effectively-infinite ceiling keeps every `limit > 0` guard and
 // percentage calc honest while never blocking an enterprise org.
 export const ENTERPRISE_DOWNLOADS = Number.MAX_SAFE_INTEGER;
+export const NEW_FREE_DOWNLOADS = 5_000;
+export const LEGACY_FREE_DOWNLOADS = 100_000;
 
-const PLAN_LIMITS: Record<PlanKey, PlanLimits> = {
-  free: { downloads: 10_000, teamMembers: false },
-  pro: { downloads: 1_000_000, teamMembers: true },
-  enterprise: { downloads: ENTERPRISE_DOWNLOADS, teamMembers: true },
+const PLAN_LIMITS: Record<Exclude<PlanKey, 'free'>, PlanLimits> = {
+  starter: { downloads: 100_000, teamMembers: false, overage: false },
+  pro: { downloads: 1_000_000, teamMembers: true, overage: true },
+  enterprise: { downloads: ENTERPRISE_DOWNLOADS, teamMembers: true, overage: false },
 };
 
 /**
@@ -29,6 +32,7 @@ function getProductToPlanMap(): Map<string, PlanKey> {
 
   const map = new Map<string, PlanKey>();
   const entries: [string | undefined, PlanKey][] = [
+    [process.env.POLAR_PRODUCT_STARTER_MONTHLY, 'starter'],
     [process.env.POLAR_PRODUCT_PRO_MONTHLY, 'pro'],
     [process.env.POLAR_PRODUCT_PRO_YEARLY, 'pro'],
   ];
@@ -50,19 +54,30 @@ export function productIdToPlanKey(productId: string | null | undefined): PlanKe
   return planKey;
 }
 
-// Pro is the only self-serve paid plan. Free needs no checkout and Enterprise is
-// a contact-sales contract, so neither maps to a Polar product.
+// Starter is monthly-only. Pro supports both billing intervals. Free needs no
+// checkout and Enterprise is a contact-sales contract.
 export function planKeyToProductId(
   planKey: PlanKey,
   interval: BillingInterval = 'month',
 ): string | null {
-  if (planKey !== 'pro') return null;
-  return interval === 'year'
-    ? (process.env.POLAR_PRODUCT_PRO_YEARLY ?? null)
-    : (process.env.POLAR_PRODUCT_PRO_MONTHLY ?? null);
+  if (planKey === 'starter') {
+    return interval === 'month' ? (process.env.POLAR_PRODUCT_STARTER_MONTHLY ?? null) : null;
+  }
+  if (planKey === 'pro') {
+    return interval === 'year'
+      ? (process.env.POLAR_PRODUCT_PRO_YEARLY ?? null)
+      : (process.env.POLAR_PRODUCT_PRO_MONTHLY ?? null);
+  }
+  return null;
 }
 
-export function getPlanLimits(planKey: PlanKey): PlanLimits {
+export function getPlanLimits(
+  planKey: PlanKey,
+  freeDownloadsLimit: number = NEW_FREE_DOWNLOADS,
+): PlanLimits {
+  if (planKey === 'free') {
+    return { downloads: freeDownloadsLimit, teamMembers: false, overage: false };
+  }
   return PLAN_LIMITS[planKey];
 }
 

--- a/packages/console/lib/billing/service.ts
+++ b/packages/console/lib/billing/service.ts
@@ -19,6 +19,7 @@ export type OrganizationEntitlements = {
 export type BillingState = {
   planKey: PlanKey;
   isActive: boolean;
+  downloadsLimit: number;
   polarSubscriptionId: string | null;
   polarCustomerId: string | null;
 };
@@ -30,13 +31,17 @@ export async function getOrganizationEntitlements(
 ): Promise<OrganizationEntitlements> {
   const organization = await db.organization.findUnique({
     where: { id: organizationId },
-    select: { planKey: true, isActive: true },
+    select: { planKey: true, isActive: true, freeDownloadsLimit: true },
   });
 
   const planKey = organization?.planKey ?? 'free';
   const isActive = organization?.isActive ?? false;
 
-  return { planKey, isActive, limits: getPlanLimits(planKey) };
+  return {
+    planKey,
+    isActive,
+    limits: getPlanLimits(planKey, organization?.freeDownloadsLimit),
+  };
 }
 
 // ── Billing state read ──────────────────────────────────────────────
@@ -47,6 +52,7 @@ export async function getBillingState(organizationId: string): Promise<BillingSt
     select: {
       planKey: true,
       isActive: true,
+      freeDownloadsLimit: true,
       polarSubscriptionId: true,
       polarCustomerId: true,
     },
@@ -56,6 +62,7 @@ export async function getBillingState(organizationId: string): Promise<BillingSt
     return {
       planKey: 'free',
       isActive: false,
+      downloadsLimit: getPlanLimits('free').downloads,
       polarSubscriptionId: null,
       polarCustomerId: null,
     };
@@ -64,6 +71,7 @@ export async function getBillingState(organizationId: string): Promise<BillingSt
   return {
     planKey: organization.planKey,
     isActive: organization.isActive,
+    downloadsLimit: getPlanLimits(organization.planKey, organization.freeDownloadsLimit).downloads,
     polarSubscriptionId: organization.polarSubscriptionId,
     polarCustomerId: organization.polarCustomerId,
   };
@@ -115,10 +123,14 @@ export async function refreshBillingState(organizationId: string): Promise<Billi
       isActive,
       polarCustomerId,
       polarSubscriptionId,
+      // Overage is a Pro-only opt-in. Clear it on cancellation or a move to
+      // Starter/Free so a stale toggle can never bypass those hard caps.
+      ...(planKey === 'pro' ? {} : { overageEnabled: false }),
     },
     select: {
       planKey: true,
       isActive: true,
+      freeDownloadsLimit: true,
       polarSubscriptionId: true,
       polarCustomerId: true,
     },
@@ -127,6 +139,7 @@ export async function refreshBillingState(organizationId: string): Promise<Billi
   return {
     planKey: organization.planKey,
     isActive: organization.isActive,
+    downloadsLimit: getPlanLimits(organization.planKey, organization.freeDownloadsLimit).downloads,
     polarSubscriptionId: organization.polarSubscriptionId,
     polarCustomerId: organization.polarCustomerId,
   };

--- a/packages/console/lib/billing/usage.ts
+++ b/packages/console/lib/billing/usage.ts
@@ -22,6 +22,7 @@ type UsageOrganizationRecord = {
   id: string;
   name: string;
   planKey: PlanKey;
+  freeDownloadsLimit: number;
   usageBlocked: boolean;
   overageEnabled: boolean;
   usagePeriodStart: Date | null;
@@ -83,6 +84,7 @@ export async function getOrganizationUsageSnapshot(
     where: { id: organizationId },
     select: {
       planKey: true,
+      freeDownloadsLimit: true,
       usagePeriodStart: true,
       downloadsCount: true,
       usageBlocked: true,
@@ -92,7 +94,7 @@ export async function getOrganizationUsageSnapshot(
   });
 
   const planKey = organization?.planKey ?? 'free';
-  const limit = getPlanLimits(planKey).downloads;
+  const limit = getPlanLimits(planKey, organization?.freeDownloadsLimit).downloads;
   const inCurrentPeriod = isSameMonth(organization?.usagePeriodStart ?? null, currentPeriodStart);
   const downloadsCount = inCurrentPeriod ? (organization?.downloadsCount ?? 0) : 0;
   const usageBlocked = inCurrentPeriod ? (organization?.usageBlocked ?? false) : false;
@@ -107,7 +109,7 @@ export async function getOrganizationUsageSnapshot(
     limit,
     percentage,
     usageBlocked,
-    overageEnabled: organization?.overageEnabled ?? false,
+    overageEnabled: planKey === 'pro' && (organization?.overageEnabled ?? false),
     warningSent,
   };
 }
@@ -123,6 +125,7 @@ export async function updateOrganizationOverageEnabled(
     select: {
       id: true,
       planKey: true,
+      freeDownloadsLimit: true,
       usageBlocked: true,
       usagePeriodStart: true,
       usageCalculatedAt: true,
@@ -142,14 +145,22 @@ export async function updateOrganizationOverageEnabled(
     ? (organization.usageCalculatedAt ?? (downloadsCount > 0 ? new Date() : currentPeriodStart))
     : currentPeriodStart;
 
-  const limit = getPlanLimits(organization.planKey).downloads;
-  const usageBlocked = isPolarConfigured() ? !overageEnabled && downloadsCount >= limit : false;
+  const limits = getPlanLimits(organization.planKey, organization.freeDownloadsLimit);
+  if (overageEnabled && !limits.overage) {
+    throw new Error('Additional usage is only available on the Pro plan');
+  }
+
+  const effectiveOverageEnabled = limits.overage && overageEnabled;
+  const limit = limits.downloads;
+  const usageBlocked = isPolarConfigured()
+    ? !effectiveOverageEnabled && downloadsCount >= limit
+    : false;
   const usageBlockedChanged = usageBlocked !== organization.usageBlocked;
 
   await db.organization.update({
     where: { id: organizationId },
     data: {
-      overageEnabled,
+      overageEnabled: effectiveOverageEnabled,
       usageBlocked,
       usagePeriodStart: currentPeriodStart,
       usageCalculatedAt,
@@ -167,7 +178,7 @@ export async function updateOrganizationOverageEnabled(
     limit,
     percentage: limit > 0 ? Math.round((downloadsCount / limit) * 100) : 0,
     usageBlocked,
-    overageEnabled,
+    overageEnabled: effectiveOverageEnabled,
     warningSent,
   };
 }
@@ -300,7 +311,8 @@ async function refreshUsageForOrganization(
     periodStart,
     periodEndExclusive: periodEnd,
   });
-  const limit = getPlanLimits(organization.planKey).downloads;
+  const limits = getPlanLimits(organization.planKey, organization.freeDownloadsLimit);
+  const limit = limits.downloads;
   const percentage = limit > 0 ? Math.round((downloadsCount / limit) * 100) : 0;
 
   let warningSent = previousWarning;
@@ -336,8 +348,9 @@ async function refreshUsageForOrganization(
     }
   }
 
+  const effectiveOverageEnabled = limits.overage && organization.overageEnabled;
   const usageBlocked = isPolarConfigured()
-    ? !organization.overageEnabled && downloadsCount >= limit
+    ? !effectiveOverageEnabled && downloadsCount >= limit
     : false;
   const usageBlockedChanged = usageBlocked !== organization.usageBlocked;
 
@@ -348,6 +361,7 @@ async function refreshUsageForOrganization(
       usageCalculatedAt: now,
       downloadsCount,
       usageBlocked,
+      overageEnabled: effectiveOverageEnabled,
       warningSent,
     },
   });
@@ -371,7 +385,7 @@ async function refreshUsageForOrganization(
       limit,
       percentage,
       usageBlocked,
-      overageEnabled: organization.overageEnabled,
+      overageEnabled: effectiveOverageEnabled,
       warningSent,
     },
     warningThresholdSent,
@@ -389,6 +403,7 @@ export async function refreshOrganizationUsageSnapshot(
       id: true,
       name: true,
       planKey: true,
+      freeDownloadsLimit: true,
       usageBlocked: true,
       overageEnabled: true,
       usagePeriodStart: true,
@@ -413,6 +428,7 @@ export async function runUsageAggregationCron(): Promise<UsageRunStats> {
       id: true,
       name: true,
       planKey: true,
+      freeDownloadsLimit: true,
       usageBlocked: true,
       overageEnabled: true,
       usagePeriodStart: true,

--- a/packages/console/prisma/migrations/20260824190000_starter_plan_grandfather_free/migration.sql
+++ b/packages/console/prisma/migrations/20260824190000_starter_plan_grandfather_free/migration.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+-- Starter is a monthly-only $10 subscription with 100k downloads. The value
+-- is added without changing any existing organization's current plan.
+ALTER TYPE "PlanKey" ADD VALUE 'starter' AFTER 'free';
+
+-- Keep the Free plan name while persisting each organization's granted Free
+-- allowance. All organizations that are Free when this migration runs are
+-- grandfathered at 100k; organizations created afterwards receive 5k.
+ALTER TABLE "Organization"
+ADD COLUMN "freeDownloadsLimit" INTEGER NOT NULL DEFAULT 5000,
+ADD CONSTRAINT "Organization_freeDownloadsLimit_positive" CHECK ("freeDownloadsLimit" > 0);
+
+UPDATE "Organization"
+SET "freeDownloadsLimit" = 100000
+WHERE "planKey" = 'free';
+
+COMMIT;

--- a/packages/console/prisma/schema.prisma
+++ b/packages/console/prisma/schema.prisma
@@ -78,6 +78,7 @@ model Verification {
 
 enum PlanKey {
   free
+  starter
   pro
   enterprise
 }
@@ -101,6 +102,9 @@ model Organization {
   name                String
   // Billing (Polar)
   planKey             PlanKey              @default(free)
+  // Persists the Free-tier allowance an organization was granted. Existing
+  // Free organizations are grandfathered at 100k; new organizations get 5k.
+  freeDownloadsLimit  Int                  @default(5000)
   isActive            Boolean              @default(false)
   polarCustomerId     String?
   polarSubscriptionId String?

--- a/packages/site/app/blog/best-live-update-frameworks-for-capacitor-apps/page.tsx
+++ b/packages/site/app/blog/best-live-update-frameworks-for-capacitor-apps/page.tsx
@@ -7,8 +7,8 @@ export const metadata = blogPostMetadata(post.slug);
 
 const comparisonRows = [
   ['Pricing based on', 'Updates delivered', 'Monthly active users + bandwidth + storage', 'Monthly active users'],
-  ['Free tier', '10,000 updates/mo, unlimited apps — free forever', '14-day trial', '14-day trial'],
-  ['First paid tier', '$25/mo (1M updates)', '$12/mo (2,000 MAU)', '$9/mo (1,000 MAU)'],
+  ['Free tier', '5,000 updates/mo, unlimited apps — free forever', '14-day trial', '14-day trial'],
+  ['First paid tier', '$10/mo (100K updates)', '$12/mo (2,000 MAU)', '$9/mo (1,000 MAU)'],
   ['Device delivery path', '100% CDN edge (Cloudflare)', 'Vendor servers', 'Vendor cloud'],
   ['End-user tracking', 'None (no device IDs)', 'Per-device (MAU metering)', 'Per-device (MAU metering)'],
   ['Security defaults', 'Signed manifests + SHA-256, always on', 'Optional signing/encryption setup', 'Optional public-key setup'],
@@ -54,8 +54,8 @@ export default function BestFrameworksPage() {
           a single user. Your privacy policy stays clean.
         </li>
         <li>
-          <strong>Dramatically cheaper.</strong> $25/mo where the others charge $79–249 for the
-          same app. The table below has the like-for-like scenarios.
+          <strong>Dramatically cheaper.</strong> $10–25/mo where the others charge $29–249 for
+          comparable apps. The table below has the like-for-like scenarios.
         </li>
         <li>
           <strong>Secure by default.</strong> ES256-signed manifests and SHA-256 verification on
@@ -72,11 +72,11 @@ export default function BestFrameworksPage() {
       </p>
       <ul>
         <li>
-          At 2,500 users: OtaKit <strong>free</strong>. Capgo <strong>$33</strong>. Capawesome{' '}
+          At 2,500 users: OtaKit <strong>$10</strong>. Capgo <strong>$33</strong>. Capawesome{' '}
           <strong>$29</strong>.
         </li>
         <li>
-          At 20,000 users: OtaKit <strong>$25</strong>. Capgo <strong>~$83</strong>. Capawesome{' '}
+          At 20,000 users: OtaKit <strong>$10</strong>. Capgo <strong>~$83</strong>. Capawesome{' '}
           <strong>$79</strong>. Roughly 3x.
         </li>
         <li>
@@ -97,8 +97,8 @@ export default function BestFrameworksPage() {
       </p>
       <p>
         OtaKit bills one number: <strong>updates delivered</strong>. Quiet month, nothing extra.
-        The free tier alone — 10,000 updates a month, unlimited apps — covers many production apps
-        indefinitely.
+        Free includes 5,000 updates a month with unlimited apps, while the $10 Starter plan raises
+        that allowance to 100,000 for growing apps.
       </p>
       <p>
         The privacy win is the same fact from the other side. A vendor can only bill per user by{' '}

--- a/packages/site/app/blog/capawesome-alternative/page.tsx
+++ b/packages/site/app/blog/capawesome-alternative/page.tsx
@@ -7,14 +7,14 @@ export const metadata = blogPostMetadata(post.slug);
 
 const priceRows = [
   ['1,000 users, 2 releases/mo', '$0 (free tier)', '$9 (Starter)'],
-  ['10,000 users, 2 releases/mo', '$0–25', '$29 (Professional)'],
+  ['10,000 users, 2 releases/mo', '$10 (Starter)', '$29 (Professional)'],
   ['50,000 users, 4 releases/mo', '$25 (Pro)', '$79 (Team)'],
   ['250,000 users, 4 releases/mo', '$25 (Pro)', '$249 (Business)'],
 ];
 
 const featureRows = [
   ['Billing meter', 'Updates delivered', 'Monthly active users'],
-  ['Free tier', '10,000 updates/mo, unlimited apps', '14-day trial'],
+  ['Free tier', '5,000 updates/mo, unlimited apps', '14-day trial'],
   ['Delta updates', 'Yes — per-file, content-addressed', 'Yes'],
   ['Bundle protection', 'Signed manifests (ES256) + SHA-256, always on; optional AES-256-GCM E2E encryption', 'Public-key signature verification'],
   ['Automatic rollback', 'Yes — notifyAppReady() handshake', 'Yes (rollback protection)'],
@@ -45,8 +45,9 @@ export default function CapawesomeAlternativePage() {
         a modestly successful side project outgrows the entry tier immediately.
       </p>
       <p>
-        OtaKit meters updates delivered, nothing else. Free covers 10,000 updates/month with
-        unlimited apps; Pro is $25/mo (billed yearly) for a million.
+        OtaKit meters updates delivered, nothing else. Free covers 5,000 updates/month with
+        unlimited apps; Starter is $10/mo for 100,000, and Pro starts at $25/mo (billed yearly)
+        for a million.
       </p>
       <DataTable headers={['Your app', 'OtaKit', 'Capawesome']} rows={priceRows} />
       <p>
@@ -94,7 +95,8 @@ export default function CapawesomeAlternativePage() {
       <Callout>
         <p>
           Bottom line: the same live updates with a stronger security pipeline, a fully
-          MIT-licensed stack, and no user tracking — $0–25/mo where Capawesome charges $29–249.
+          MIT-licensed stack, and no user tracking — $10–25/mo for typical paid usage where
+          Capawesome charges $29–249.
         </p>
       </Callout>
 

--- a/packages/site/app/blog/capgo-alternative/page.tsx
+++ b/packages/site/app/blog/capgo-alternative/page.tsx
@@ -7,7 +7,7 @@ export const metadata = blogPostMetadata(post.slug);
 
 const priceRows = [
   ['2,000 users, 2 releases/mo', '$0 (free tier)', '$12 (Solo)'],
-  ['10,000 users, 2 releases/mo', '$0–25', '$33 (Maker)'],
+  ['10,000 users, 2 releases/mo', '$10 (Starter)', '$33 (Maker)'],
   ['50,000 users, 4 releases/mo', '$25 (Pro)', '$83 (Team)'],
   ['500,000 users, 4 releases/mo', '$75 (Pro + overage)', '$208+ (Enterprise)'],
 ];
@@ -44,10 +44,10 @@ export default function CapgoAlternativePage() {
         each cap.
       </p>
       <p>
-        OtaKit bills on one meter: <strong>updates delivered</strong>. Free covers 10,000
-        updates/month with unlimited apps and releases; Pro is $25/mo (billed yearly) for 1
-        million, then $50 per additional million. No MAU count, no bandwidth meter, no storage
-        meter.
+        OtaKit bills on one meter: <strong>updates delivered</strong>. Free covers 5,000
+        updates/month with unlimited apps and releases; Starter is $10/mo for 100,000 updates, and
+        Pro is $25/mo (billed yearly) for 1 million, then $50 per additional million. No MAU count,
+        no bandwidth meter, no storage meter.
       </p>
       <DataTable headers={['Your app', 'OtaKit', 'Capgo']} rows={priceRows} />
       <p>
@@ -92,7 +92,7 @@ export default function CapgoAlternativePage() {
       <Callout>
         <p>
           Bottom line: the same live updates, delivered from a stronger network, with zero user
-          tracking and one predictable bill — $0–25/mo for most apps that pay Capgo $33–208+.
+          tracking and one predictable bill — $10–25/mo for most apps that pay Capgo $33–208+.
         </p>
       </Callout>
 

--- a/packages/site/app/blog/the-1-alternative-to-capgo-capawesome/page.tsx
+++ b/packages/site/app/blog/the-1-alternative-to-capgo-capawesome/page.tsx
@@ -6,7 +6,7 @@ const post = getBlogPost('the-1-alternative-to-capgo-capawesome')!;
 export const metadata = blogPostMetadata(post.slug);
 
 const priceRows = [
-  ['5,000 users, 2 releases/mo', '$0 (free tier)', '$33 (Maker, 10K MAU)', '$29 (10K MAU)'],
+  ['5,000 users, 2 releases/mo', '$10 (Starter)', '$33 (Maker, 10K MAU)', '$29 (10K MAU)'],
   ['50,000 users, 4 releases/mo', '$25 (Pro)', '$83 (Team, 100K MAU)', '$79 (50K MAU)'],
   ['250,000 users, 4 releases/mo', '$25 (Pro)', '$208+ (Enterprise)', '$249 (250K MAU)'],
 ];
@@ -29,10 +29,10 @@ export default function AlternativePage() {
         forever.
       </p>
       <p>
-        OtaKit meters one thing: <strong>updates actually delivered</strong>. Free covers 10,000
-        updates a month with unlimited apps; Pro is $25/mo (billed yearly) for a million. Here is
-        what that means at real-world sizes, using each vendor&apos;s public pricing as of July
-        2026:
+        OtaKit meters one thing: <strong>updates actually delivered</strong>. Free covers 5,000
+        updates a month with unlimited apps; Starter is $10/mo for 100,000, and Pro starts at
+        $25/mo (billed yearly) for a million. Here is what that means at real-world sizes, using
+        each vendor&apos;s public pricing as of July 2026:
       </p>
       <DataTable
         headers={['Your app', 'OtaKit', 'Capgo', 'Capawesome (Live Updates)']}

--- a/packages/site/app/page.tsx
+++ b/packages/site/app/page.tsx
@@ -596,7 +596,13 @@ export default function LandingPage() {
                 name="Pro"
                 price="$25"
                 period="/mo"
-                description="Billed yearly ($300/yr) or $50 billed monthly."
+                description={
+                  <>
+                    Billed yearly ($300/yr)
+                    <br />
+                    or $50 billed monthly.
+                  </>
+                }
                 allowance="1,000,000 updates / month"
                 features={[
                   'Everything in Free',
@@ -923,7 +929,7 @@ function PricingCard({
   name: string;
   price: string;
   period: string;
-  description: string;
+  description: React.ReactNode;
   allowance: string;
   features: string[];
   cta: string;

--- a/packages/site/app/page.tsx
+++ b/packages/site/app/page.tsx
@@ -557,17 +557,17 @@ export default function LandingPage() {
                 Simple, value-aligned pricing
               </h2>
               <p className="mt-4 max-w-3xl text-muted-foreground">
-                Pricing is based on live updates delivered — no seats, end-user tracking, bandwidth,
-                or storage.
+                Pricing is based on live updates delivered — no seat fees, end-user tracking,
+                bandwidth, or storage.
               </p>
             </div>
-            <div className="grid gap-px bg-border sm:grid-cols-3">
+            <div className="grid gap-px bg-border sm:grid-cols-2 lg:grid-cols-4">
               <PricingCard
                 name="Free"
                 price="$0"
                 period="/mo"
                 description="Free forever for early usage."
-                allowance="10,000 updates / month"
+                allowance="5,000 updates / month"
                 features={[
                   'Unlimited releases',
                   'Unlimited apps',
@@ -576,6 +576,21 @@ export default function LandingPage() {
                   'Real-time analytics',
                 ]}
                 cta="Get started free"
+              />
+              <PricingCard
+                name="Starter"
+                price="$10"
+                period="/mo"
+                description="Billed monthly. No annual plan."
+                allowance="100,000 updates / month"
+                features={[
+                  'Everything in Free',
+                  '20× the Free allowance',
+                  'Single-member workspace',
+                  'Hard cap — no overage',
+                ]}
+                cta="Start with Starter"
+                highlighted
               />
               <PricingCard
                 name="Pro"
@@ -590,7 +605,6 @@ export default function LandingPage() {
                   'Priority support',
                 ]}
                 cta="Start with Pro"
-                highlighted
               />
               <PricingCard
                 name="Enterprise"

--- a/packages/site/app/vs/_components/ComparisonLanding.tsx
+++ b/packages/site/app/vs/_components/ComparisonLanding.tsx
@@ -418,17 +418,17 @@ export function ComparisonLanding({ copy }: { copy: ComparisonCopy }) {
                 Simple, value-aligned pricing
               </h2>
               <p className="mt-4 max-w-3xl text-muted-foreground">
-                Pricing is based on live updates delivered — no seats, end-user tracking, bandwidth,
-                or storage.
+                Pricing is based on live updates delivered — no seat fees, end-user tracking,
+                bandwidth, or storage.
               </p>
             </div>
-            <div className="grid gap-px bg-border sm:grid-cols-3">
+            <div className="grid gap-px bg-border sm:grid-cols-2 lg:grid-cols-4">
               <PricingCard
                 name="Free"
                 price="$0"
                 period="/mo"
                 description="Free forever for early usage."
-                allowance="10,000 updates / month"
+                allowance="5,000 updates / month"
                 features={[
                   'Unlimited releases',
                   'Unlimited apps',
@@ -437,6 +437,21 @@ export function ComparisonLanding({ copy }: { copy: ComparisonCopy }) {
                   'Real-time analytics',
                 ]}
                 cta="Get started free"
+              />
+              <PricingCard
+                name="Starter"
+                price="$10"
+                period="/mo"
+                description="Billed monthly. No annual plan."
+                allowance="100,000 updates / month"
+                features={[
+                  'Everything in Free',
+                  '20× the Free allowance',
+                  'Single-member workspace',
+                  'Hard cap — no overage',
+                ]}
+                cta="Start with Starter"
+                highlighted
               />
               <PricingCard
                 name="Pro"
@@ -451,7 +466,6 @@ export function ComparisonLanding({ copy }: { copy: ComparisonCopy }) {
                   'Priority support',
                 ]}
                 cta="Start with Pro"
-                highlighted
               />
               <PricingCard
                 name="Enterprise"

--- a/packages/site/app/vs/_components/ComparisonLanding.tsx
+++ b/packages/site/app/vs/_components/ComparisonLanding.tsx
@@ -457,7 +457,13 @@ export function ComparisonLanding({ copy }: { copy: ComparisonCopy }) {
                 name="Pro"
                 price="$25"
                 period="/mo"
-                description="Billed yearly ($300/yr) or $50 billed monthly."
+                description={
+                  <>
+                    Billed yearly ($300/yr)
+                    <br />
+                    or $50 billed monthly.
+                  </>
+                }
                 allowance="1,000,000 updates / month"
                 features={[
                   'Everything in Free',
@@ -768,7 +774,7 @@ function PricingCard({
   name: string;
   price: string;
   period: string;
-  description: string;
+  description: React.ReactNode;
   allowance: string;
   features: string[];
   cta: string;

--- a/packages/site/app/vs/capawesome/page.tsx
+++ b/packages/site/app/vs/capawesome/page.tsx
@@ -83,8 +83,8 @@ const copy: ComparisonCopy = {
             Capawesome’s live-update plans are gated by monthly active users — $9/mo covers just
             1,000 MAU, then $29 (10K), $79 (50K), $249 (250K) — and every active device counts
             every month, whether you release or not. OtaKit meters{' '}
-            <strong>updates delivered</strong>, nothing else: Free covers 10,000 updates/month with
-            unlimited apps; Pro is $25/mo for 1 million.
+            <strong>updates delivered</strong>, nothing else: Free covers 5,000 updates/month with
+            unlimited apps; Starter is $10/mo for 100,000, and Pro starts at $25/mo for 1 million.
           </p>
           <p>
             At 250,000 users the difference is $25 vs $249 — ten to one, every month, for the same

--- a/packages/site/app/vs/capgo/page.tsx
+++ b/packages/site/app/vs/capgo/page.tsx
@@ -84,11 +84,12 @@ const copy: ComparisonCopy = {
           <p>
             Capgo bills on three meters — monthly active users, bandwidth, and storage — so every
             active device counts against your plan every month, even if you ship nothing. OtaKit
-            bills on one meter: <strong>updates delivered</strong>. Free covers 10,000
-            updates/month with unlimited apps; Pro is $25/mo for 1 million.
+            bills on one meter: <strong>updates delivered</strong>. Free covers 5,000
+            updates/month with unlimited apps; Starter is $10/mo for 100,000, and Pro starts at
+            $25/mo for 1 million.
           </p>
           <p>
-            In practice: 10,000 users at 2 releases/mo is $0–25 on OtaKit vs $33 on Capgo; 50,000
+            In practice: 10,000 users at 2 releases/mo is $10 on OtaKit vs $33 on Capgo; 50,000
             users at 4 releases/mo is $25 vs $83; 500,000 users is $75 vs $208+. The{' '}
             <GuideLink href="/blog/capgo-alternative">full comparison</GuideLink> shows the math.
           </p>


### PR DESCRIPTION
## Summary

- add a monthly-only $10 Starter plan with 100,000 included updates, no team members, and no overage
- lower new Free organizations to 5,000 updates while preserving 100,000 for every existing Free organization
- enforce plan-specific limits across usage blocking, overage, invitations, checkout, and billing refresh
- add a four-tier pricing presentation to the console, homepage, comparison pages, and pricing articles
- trust OtaKit console Vercel preview origins in Better Auth

## Data and billing operations

- deployed the additive database migration; all 69 existing Free organizations were verified at the 100,000 grandfathered allowance and the new default was verified at 5,000
- created Polar product `OtaKit Starter` (`d3ad4359-d741-470f-82d2-51e865548e3f`) with one $10 monthly fixed price, the 100,000 non-rollover downloads benefit, and no metered/overage price
- kept the Starter product archived until this PR is merged so it cannot be purchased against old production code
- configured the Starter product, meter, and usage-event Vercel environment variables for production, preview, and development
- corrected the Polar webhook URL to `https://console.otakit.app/api/webhook/polar` and subscribed it to all supported billing state events

## Verification

- `pnpm --filter @otakit/console typecheck`
- `pnpm --filter @otakit/console lint`
- `pnpm --filter @otakit/site typecheck`
- ESLint on all changed site files
- `pnpm prisma validate`
- `pnpm prisma migrate status`
- `pnpm --filter @otakit/console build`
- `pnpm --filter @otakit/site build`
- billing limit/product mapping assertions
- live Polar catalog, benefit, webhook, and Vercel environment verification

Repository-wide site lint still has eight pre-existing `react/no-unescaped-entities` errors in `app/docs/self-host/page.tsx` plus one unrelated warning; all files changed by this PR lint clean.