### PR TITLE
docs: add canonical link to llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,5 +1,7 @@
 # OtaKit Docs
 
+Canonical documentation: https://otakit.app/docs
+
 Generated from the public docs pages in `packages/site/app/docs`.
 
 ## Pages

--- a/packages/site/public/llms.txt
+++ b/packages/site/public/llms.txt
@@ -1,5 +1,7 @@
 # OtaKit Docs
 
+Canonical documentation: https://otakit.app/docs
+
 Generated from the public docs pages in `packages/site/app/docs`.
 
 ## Pages

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -100,6 +100,8 @@ function buildDocument(sections) {
   const lines = [
     '# OtaKit Docs',
     '',
+    'Canonical documentation: https://otakit.app/docs',
+    '',
     'Generated from the public docs pages in `packages/site/app/docs`.',
     '',
     '## Pages',


### PR DESCRIPTION
Adds the canonical documentation URL to the generated `llms.txt` header.

The generator and both generated copies stay in sync. No runtime behavior changes.