### PR TITLE
fix(console): stop connect commands overflowing their dialog

### DIFF
--- a/packages/console/app/components/agents/ConnectAgentDialog.tsx
+++ b/packages/console/app/components/agents/ConnectAgentDialog.tsx
@@ -92,7 +92,7 @@ function NumberedStep({ index, step }: { index: number; step: Step }) {
           <p className="text-[13px] font-medium">{step.label}</p>
           <CopyButton value={step.command} label={step.label} />
         </div>
-        <pre className="overflow-x-auto rounded-lg border border-border bg-muted/60 px-3 py-2.5 text-[11px] leading-relaxed">
+        <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-border bg-muted/60 px-3 py-2.5 text-[11px] leading-relaxed">
           <code>{step.command}</code>
         </pre>
       </div>
@@ -117,7 +117,7 @@ export function ConnectAgentDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Connect an agent</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
The connect dialog was `sm:max-w-lg` (512px) and its `<pre>` blocks only had `overflow-x-auto`, so long commands ran off the side:

| line | renders | fits |
|---|---|---|
| VS Code `"args": [...]` | ~87 chars | ~63 |
| `claude mcp add … --project-root '${CLAUDE_PROJECT_DIR:-.}'` | ~72 chars | ~63 |

Two changes, both wanted:

- **Wider** — `sm:max-w-2xl` (672px), which fits the longest line outright.
- **Wrapping** — `whitespace-pre-wrap break-words`, so a longer command, a self-hosted `--server` flag, or a narrow window folds instead of hiding.

Wrapping is safe: Copy sends the raw `step.command` string, never the rendered text, so a visually wrapped line cannot change what gets pasted.

Audited the rest — every `<pre>` in the console now wraps; this was the last one that didn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMqnYqbUSzDGEguHmrgWij