### PR TITLE
Add business onboarding before dashboard app setup

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -74,7 +74,9 @@ This is the most simple, default hosted setup path.
 
 ### 1. Connect your app in the dashboard
 
-Sign in to the OtaKit dashboard , choose “Connect your app”, and copy its OtaKit `appId`. The floating setup panel also guides you through connecting your project. Your app identifier can be a simple label such as `my-app`; it does not need to match your native app ID.
+Sign in to the OtaKit dashboard and choose “Connect your app”. Give it a label that is unique in your workspace, such as `my-app`; it does not need to match your native app ID.
+
+OtaKit generates a separate app ID. Copy that generated value from the dashboard into `plugins.OtaKit.appId`, not the label you entered. The floating setup panel guides you through connecting your project.
 
 ### 2. Install the Capacitor plugin
 

--- a/llms.txt
+++ b/llms.txt
@@ -72,9 +72,9 @@ Set up the default hosted OtaKit flow in a Capacitor project.
 
 This is the most simple, default hosted setup path.
 
-### 1. Create your app in the dashboard
+### 1. Connect your app in the dashboard
 
-Sign in to the OtaKit dashboard , create an app, and copy its OtaKit `appId`.
+Sign in to the OtaKit dashboard , choose “Connect your app”, and copy its OtaKit `appId`. If you already registered your app during onboarding, use the ID shown there. Your app identifier can be a simple label such as `my-app`; it does not need to match your native app ID.
 
 ### 2. Install the Capacitor plugin
 
@@ -105,7 +105,7 @@ const config: CapacitorConfig = {
 export default config;
 ```
 
-Note: Your app must be published to the app store at least once with the OtaKit plugin configured before it can receive updates!
+Build and install the native app with the OtaKit plugin configured before testing OTA. A local test build is enough to get started. To reach existing users, publish an App Store or Google Play build containing the plugin; those users can receive OtaKit updates after installing that build.
 
 Optional: if you want something other than the hosted defaults, you can also set `launchPolicy`, `resumePolicy`, `runtimePolicy`, and `checkInterval`. See the Plugin API page for the full configuration surface.
 

--- a/llms.txt
+++ b/llms.txt
@@ -74,7 +74,7 @@ This is the most simple, default hosted setup path.
 
 ### 1. Connect your app in the dashboard
 
-Sign in to the OtaKit dashboard , choose “Connect your app”, and copy its OtaKit `appId`. If you already registered your app during onboarding, use the ID shown there. Your app identifier can be a simple label such as `my-app`; it does not need to match your native app ID.
+Sign in to the OtaKit dashboard , choose “Connect your app”, and copy its OtaKit `appId`. The floating setup panel also guides you through connecting your project. Your app identifier can be a simple label such as `my-app`; it does not need to match your native app ID.
 
 ### 2. Install the Capacitor plugin
 

--- a/packages/console/app/api/v1/organization/billing/checkout/route.test.ts
+++ b/packages/console/app/api/v1/organization/billing/checkout/route.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  getSessionContext: vi.fn(),
+  findUnique: vi.fn(),
+  createCheckout: vi.fn(),
+  isPolarConfigured: vi.fn(),
+  planKeyToProductId: vi.fn(),
+}));
+vi.mock('@/lib/session', () => ({ getSessionContext: mocks.getSessionContext }));
+vi.mock('@/lib/db', () => ({ db: { organization: { findUnique: mocks.findUnique } } }));
+vi.mock('@/lib/polar', () => ({
+  isPolarConfigured: mocks.isPolarConfigured,
+  getPolar: () => ({ checkouts: { create: mocks.createCheckout } }),
+}));
+vi.mock('@/lib/billing/config', () => ({
+  planKeyToProductId: mocks.planKeyToProductId,
+  getExternalCustomerId: (id: string) => `organization:${id}`,
+}));
+import { POST } from './route';
+
+function request(body: unknown, organizationId = 'org-1') {
+  return new NextRequest('https://console.example/api/v1/organization/billing/checkout', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-otakit-organization-id': organizationId },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('billing checkout return paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSessionContext.mockResolvedValue({
+      organizationId: 'org-1',
+      userId: 'user-1',
+      email: 'user@example.test',
+      role: 'owner',
+    });
+    mocks.findUnique.mockResolvedValue({ isActive: false });
+    mocks.isPolarConfigured.mockReturnValue(true);
+    mocks.planKeyToProductId.mockReturnValue('product-pro-yearly');
+    mocks.createCheckout.mockResolvedValue({ url: 'https://checkout.example/session' });
+  });
+  it('returns onboarding checkout to setup and provides a safe cancel path', async () => {
+    const response = await POST(
+      request({ planKey: 'pro', interval: 'year', returnTo: 'onboarding' }),
+    );
+    expect(response.status).toBe(201);
+    expect(mocks.createCheckout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        successUrl: 'https://console.example/onboarding?checkout=success',
+        returnUrl: 'https://console.example/onboarding',
+        externalCustomerId: 'organization:org-1',
+        metadata: expect.objectContaining({ billingInterval: 'year' }),
+      }),
+    );
+  });
+  it.each([undefined, 'https://untrusted.example'])(
+    'keeps the settings return path for %s',
+    async (returnTo) => {
+      expect((await POST(request({ planKey: 'starter', returnTo }))).status).toBe(201);
+      expect(mocks.createCheckout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          successUrl: 'https://console.example/dashboard/settings?pricing=1&checkout=success',
+        }),
+      );
+      expect(mocks.createCheckout.mock.calls[0][0]).not.toHaveProperty('returnUrl');
+    },
+  );
+  it('rejects a workspace changed in another tab before initiating billing', async () => {
+    expect((await POST(request({ planKey: 'pro' }, 'org-2'))).status).toBe(409);
+    expect(mocks.createCheckout).not.toHaveBeenCalled();
+  });
+  it('does not create a second active subscription', async () => {
+    mocks.findUnique.mockResolvedValue({ isActive: true });
+    expect((await POST(request({ planKey: 'pro', returnTo: 'onboarding' }))).status).toBe(409);
+    expect(mocks.createCheckout).not.toHaveBeenCalled();
+  });
+  it('returns a retryable failure when the billing provider is unavailable', async () => {
+    mocks.createCheckout.mockRejectedValue(new Error('Provider unavailable'));
+    expect((await POST(request({ planKey: 'starter' }))).status).toBe(502);
+  });
+});

--- a/packages/console/app/api/v1/organization/billing/checkout/route.test.ts
+++ b/packages/console/app/api/v1/organization/billing/checkout/route.test.ts
@@ -42,15 +42,15 @@ describe('billing checkout return paths', () => {
     mocks.planKeyToProductId.mockReturnValue('product-pro-yearly');
     mocks.createCheckout.mockResolvedValue({ url: 'https://checkout.example/session' });
   });
-  it('returns onboarding checkout to setup and provides a safe cancel path', async () => {
+  it('returns successful and cancelled welcome checkout to the dashboard', async () => {
     const response = await POST(
-      request({ planKey: 'pro', interval: 'year', returnTo: 'onboarding' }),
+      request({ planKey: 'pro', interval: 'year', returnTo: 'dashboard' }),
     );
     expect(response.status).toBe(201);
     expect(mocks.createCheckout).toHaveBeenCalledWith(
       expect.objectContaining({
-        successUrl: 'https://console.example/onboarding?checkout=success',
-        returnUrl: 'https://console.example/onboarding',
+        successUrl: 'https://console.example/dashboard',
+        returnUrl: 'https://console.example/dashboard',
         externalCustomerId: 'organization:org-1',
         metadata: expect.objectContaining({ billingInterval: 'year' }),
       }),
@@ -74,7 +74,7 @@ describe('billing checkout return paths', () => {
   });
   it('does not create a second active subscription', async () => {
     mocks.findUnique.mockResolvedValue({ isActive: true });
-    expect((await POST(request({ planKey: 'pro', returnTo: 'onboarding' }))).status).toBe(409);
+    expect((await POST(request({ planKey: 'pro', returnTo: 'dashboard' }))).status).toBe(409);
     expect(mocks.createCheckout).not.toHaveBeenCalled();
   });
   it('returns a retryable failure when the billing provider is unavailable', async () => {

--- a/packages/console/app/api/v1/organization/billing/checkout/route.test.ts
+++ b/packages/console/app/api/v1/organization/billing/checkout/route.test.ts
@@ -42,14 +42,14 @@ describe('billing checkout return paths', () => {
     mocks.planKeyToProductId.mockReturnValue('product-pro-yearly');
     mocks.createCheckout.mockResolvedValue({ url: 'https://checkout.example/session' });
   });
-  it('returns successful and cancelled welcome checkout to the dashboard', async () => {
+  it('returns successful welcome checkout to a workspace-scoped status check and the back button to the dashboard', async () => {
     const response = await POST(
       request({ planKey: 'pro', interval: 'year', returnTo: 'dashboard' }),
     );
     expect(response.status).toBe(201);
     expect(mocks.createCheckout).toHaveBeenCalledWith(
       expect.objectContaining({
-        successUrl: 'https://console.example/dashboard',
+        successUrl: 'https://console.example/dashboard?checkout=onboarding&checkout_org=org-1',
         returnUrl: 'https://console.example/dashboard',
         externalCustomerId: 'organization:org-1',
         metadata: expect.objectContaining({ billingInterval: 'year' }),

--- a/packages/console/app/api/v1/organization/billing/checkout/route.ts
+++ b/packages/console/app/api/v1/organization/billing/checkout/route.ts
@@ -95,7 +95,7 @@ export async function POST(request: NextRequest) {
       customerEmail: ctx.email,
       successUrl:
         body.returnTo === 'dashboard'
-          ? `${appUrl}/dashboard`
+          ? `${appUrl}/dashboard?checkout=onboarding&checkout_org=${encodeURIComponent(ctx.organizationId)}`
           : `${appUrl}/dashboard/settings?pricing=1&checkout=success`,
       ...(body.returnTo === 'dashboard' ? { returnUrl: `${appUrl}/dashboard` } : {}),
       metadata: {

--- a/packages/console/app/api/v1/organization/billing/checkout/route.ts
+++ b/packages/console/app/api/v1/organization/billing/checkout/route.ts
@@ -34,6 +34,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 });
   }
 
+  const expectedOrganization = request.headers.get('x-otakit-organization-id');
+  if (expectedOrganization && expectedOrganization !== ctx.organizationId) {
+    return NextResponse.json(
+      { error: 'Your active workspace changed. Reload to continue.' },
+      { status: 409 },
+    );
+  }
+
   const body = await request.json().catch(() => null);
   if (!body || !VALID_PLAN_KEYS.has(body.planKey)) {
     return NextResponse.json(
@@ -85,7 +93,11 @@ export async function POST(request: NextRequest) {
       products: [productId],
       externalCustomerId: getExternalCustomerId(ctx.organizationId),
       customerEmail: ctx.email,
-      successUrl: `${appUrl}/dashboard/settings?pricing=1&checkout=success`,
+      successUrl:
+        body.returnTo === 'onboarding'
+          ? `${appUrl}/onboarding?checkout=success`
+          : `${appUrl}/dashboard/settings?pricing=1&checkout=success`,
+      ...(body.returnTo === 'onboarding' ? { returnUrl: `${appUrl}/onboarding` } : {}),
       metadata: {
         organizationId: ctx.organizationId,
         initiatedByUserId: ctx.userId,

--- a/packages/console/app/api/v1/organization/billing/checkout/route.ts
+++ b/packages/console/app/api/v1/organization/billing/checkout/route.ts
@@ -94,10 +94,10 @@ export async function POST(request: NextRequest) {
       externalCustomerId: getExternalCustomerId(ctx.organizationId),
       customerEmail: ctx.email,
       successUrl:
-        body.returnTo === 'onboarding'
-          ? `${appUrl}/onboarding?checkout=success`
+        body.returnTo === 'dashboard'
+          ? `${appUrl}/dashboard`
           : `${appUrl}/dashboard/settings?pricing=1&checkout=success`,
-      ...(body.returnTo === 'onboarding' ? { returnUrl: `${appUrl}/onboarding` } : {}),
+      ...(body.returnTo === 'dashboard' ? { returnUrl: `${appUrl}/dashboard` } : {}),
       metadata: {
         organizationId: ctx.organizationId,
         initiatedByUserId: ctx.userId,

--- a/packages/console/app/api/v1/organization/billing/refresh/route.test.ts
+++ b/packages/console/app/api/v1/organization/billing/refresh/route.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mocks = vi.hoisted(() => ({
+  getSessionContext: vi.fn(),
+  isPolarConfigured: vi.fn(),
+  refreshBillingState: vi.fn(),
+}));
+vi.mock('@/lib/session', () => ({ getSessionContext: mocks.getSessionContext }));
+vi.mock('@/lib/polar', () => ({ isPolarConfigured: mocks.isPolarConfigured }));
+vi.mock('@/lib/billing/service', () => ({ refreshBillingState: mocks.refreshBillingState }));
+import { POST } from './route';
+
+function request(organizationId?: string) {
+  return new NextRequest('https://console.example/api/v1/organization/billing/refresh', {
+    method: 'POST',
+    headers: organizationId ? { 'x-otakit-organization-id': organizationId } : {},
+  });
+}
+describe('billing refresh workspace scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isPolarConfigured.mockReturnValue(true);
+    mocks.getSessionContext.mockResolvedValue({ organizationId: 'org-1' });
+    mocks.refreshBillingState.mockResolvedValue({ isActive: true, planKey: 'pro' });
+  });
+  it('rejects a stale checkout workspace before contacting the billing provider', async () => {
+    expect((await POST(request('org-2'))).status).toBe(409);
+    expect(mocks.refreshBillingState).not.toHaveBeenCalled();
+  });
+  it.each([undefined, 'org-1'])(
+    'refreshes the resolved workspace with expected scope %s',
+    async (expected) => {
+      const response = await POST(request(expected));
+      expect(response.status).toBe(200);
+      expect(mocks.refreshBillingState).toHaveBeenCalledWith('org-1');
+      expect(await response.json()).toEqual({ billing: { isActive: true, planKey: 'pro' } });
+    },
+  );
+  it('requires authentication', async () => {
+    mocks.getSessionContext.mockResolvedValue(null);
+    expect((await POST(request('org-1'))).status).toBe(401);
+    expect(mocks.refreshBillingState).not.toHaveBeenCalled();
+  });
+  it('does not confirm a plan when the billing provider fails', async () => {
+    mocks.refreshBillingState.mockRejectedValue(new Error('Unavailable'));
+    expect((await POST(request('org-1'))).status).toBe(502);
+  });
+});

--- a/packages/console/app/api/v1/organization/billing/refresh/route.ts
+++ b/packages/console/app/api/v1/organization/billing/refresh/route.ts
@@ -1,11 +1,11 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getSessionContext } from '@/lib/session';
 import { isPolarConfigured } from '@/lib/polar';
 import { refreshBillingState } from '@/lib/billing/service';
 
 export const runtime = 'nodejs';
 
-export async function POST() {
+export async function POST(request: NextRequest) {
   if (!isPolarConfigured()) {
     return NextResponse.json(
       { error: 'Billing is not configured on this instance' },
@@ -16,6 +16,14 @@ export async function POST() {
   const ctx = await getSessionContext();
   if (!ctx) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const expectedOrganization = request.headers.get('x-otakit-organization-id');
+  if (expectedOrganization && expectedOrganization !== ctx.organizationId) {
+    return NextResponse.json(
+      { error: 'Your active workspace changed. Reload to continue.' },
+      { status: 409 },
+    );
   }
 
   try {

--- a/packages/console/app/api/v1/organization/onboarding/profile/route.test.ts
+++ b/packages/console/app/api/v1/organization/onboarding/profile/route.test.ts
@@ -60,6 +60,7 @@ describe('onboarding profile route', () => {
     for (const body of [
       null,
       { action: 'save', step: 'audience', answers: { activeUsers: -1 } },
+      { action: 'skip', answers: { activeUsers: -1 } },
       { action: 'skip', organizationId: 'org-2' },
       { action: 'complete', answers: {}, slug: 'my-app' },
       { action: 'save', answers: {}, step: 'plans' },

--- a/packages/console/app/api/v1/organization/onboarding/profile/route.test.ts
+++ b/packages/console/app/api/v1/organization/onboarding/profile/route.test.ts
@@ -59,8 +59,10 @@ describe('onboarding profile route', () => {
   it('rejects malformed answers and caller-supplied organization IDs', async () => {
     for (const body of [
       null,
-      { action: 'save', step: 'connect', answers: { activeUsers: -1 } },
+      { action: 'save', step: 'audience', answers: { activeUsers: -1 } },
       { action: 'skip', organizationId: 'org-2' },
+      { action: 'complete', answers: {}, slug: 'my-app' },
+      { action: 'save', answers: {}, step: 'plans' },
     ]) {
       expect((await POST(request(body))).status).toBe(400);
     }

--- a/packages/console/app/api/v1/organization/onboarding/profile/route.test.ts
+++ b/packages/console/app/api/v1/organization/onboarding/profile/route.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { OtaKitServiceError } from '@/lib/services/errors';
+
+const mocks = vi.hoisted(() => ({
+  getSessionContext: vi.fn(),
+  getOnboardingProfile: vi.fn(),
+  updateOnboardingProfile: vi.fn(),
+}));
+vi.mock('@/lib/session', () => ({ getSessionContext: mocks.getSessionContext }));
+vi.mock('@/lib/services/onboarding-profile', () => ({
+  getOnboardingProfile: mocks.getOnboardingProfile,
+  updateOnboardingProfile: mocks.updateOnboardingProfile,
+}));
+import { GET, POST } from './route';
+
+const ctx = {
+  userId: 'user-1',
+  email: 'test@example.test',
+  organizationId: 'org-1',
+  role: 'owner',
+};
+function request(body: unknown, organizationId = 'org-1') {
+  return new NextRequest('https://console.example/api/v1/organization/onboarding/profile', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-otakit-organization-id': organizationId },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('onboarding profile route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSessionContext.mockResolvedValue(ctx);
+    mocks.getOnboardingProfile.mockResolvedValue(null);
+    mocks.updateOnboardingProfile.mockResolvedValue({ step: 'app' });
+  });
+  it('requires a valid session for reads and writes', async () => {
+    mocks.getSessionContext.mockResolvedValue(null);
+    expect((await GET()).status).toBe(401);
+    expect((await POST(request({ action: 'skip' }))).status).toBe(401);
+    expect(mocks.getOnboardingProfile).not.toHaveBeenCalled();
+    expect(mocks.updateOnboardingProfile).not.toHaveBeenCalled();
+  });
+  it('reads only the active workspace and passes the resolved identity to writes', async () => {
+    await GET();
+    expect(mocks.getOnboardingProfile).toHaveBeenCalledWith('org-1');
+    await POST(request({ action: 'save', step: 'app', answers: { technology: 'capacitor' } }));
+    expect(mocks.updateOnboardingProfile).toHaveBeenCalledWith(ctx, {
+      action: 'save',
+      step: 'app',
+      answers: { technology: 'capacitor' },
+    });
+  });
+  it('rejects a stale workspace instead of connecting the app to a different organization', async () => {
+    expect((await POST(request({ action: 'skip' }, 'org-2'))).status).toBe(409);
+    expect(mocks.updateOnboardingProfile).not.toHaveBeenCalled();
+  });
+  it('rejects malformed answers and caller-supplied organization IDs', async () => {
+    for (const body of [
+      null,
+      { action: 'save', step: 'connect', answers: { activeUsers: -1 } },
+      { action: 'skip', organizationId: 'org-2' },
+    ]) {
+      expect((await POST(request(body))).status).toBe(400);
+    }
+    expect(mocks.updateOnboardingProfile).not.toHaveBeenCalled();
+  });
+  it('returns service authorization and validation failures without hiding their status', async () => {
+    mocks.updateOnboardingProfile.mockRejectedValue(
+      new OtaKitServiceError('INSUFFICIENT_ROLE', 'Owners and admins only.', 403),
+    );
+    const response = await POST(request({ action: 'skip' }));
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: 'Owners and admins only.' });
+  });
+});

--- a/packages/console/app/api/v1/organization/onboarding/profile/route.ts
+++ b/packages/console/app/api/v1/organization/onboarding/profile/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getSessionContext } from '@/lib/session';
+import { onboardingRequestSchema } from '@/lib/onboarding-profile';
+import { getOnboardingProfile, updateOnboardingProfile } from '@/lib/services/onboarding-profile';
+import { serviceErrorResponse } from '@/lib/services/http';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const ctx = await getSessionContext();
+  if (!ctx) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  try {
+    return NextResponse.json({ profile: await getOnboardingProfile(ctx.organizationId) });
+  } catch (error) {
+    return serviceErrorResponse(error);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const ctx = await getSessionContext();
+  if (!ctx) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  const expectedOrganization = request.headers.get('x-otakit-organization-id');
+  if (expectedOrganization && expectedOrganization !== ctx.organizationId) {
+    return NextResponse.json(
+      { error: 'Your active workspace changed. Reload to continue.' },
+      { status: 409 },
+    );
+  }
+  const parsed = onboardingRequestSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Check your answers and try again.', fields: parsed.error.flatten().fieldErrors },
+      { status: 400 },
+    );
+  }
+  try {
+    return NextResponse.json({ profile: await updateOnboardingProfile(ctx, parsed.data) });
+  } catch (error) {
+    return serviceErrorResponse(error);
+  }
+}

--- a/packages/console/app/components/CheckoutStatus.tsx
+++ b/packages/console/app/components/CheckoutStatus.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { LoaderCircle } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+type Status = { message: string; retry?: boolean; settings?: boolean; signIn?: boolean };
+
+export function CheckoutStatus({ organizationId }: { organizationId: string }) {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    if (url.searchParams.get('checkout') !== 'onboarding') return;
+    if (url.searchParams.get('checkout_org') !== organizationId) {
+      setStatus({
+        message:
+          'This checkout belongs to another workspace. Switch to it in Settings to view its plan.',
+        settings: true,
+      });
+      return;
+    }
+    let cancelled = false;
+    setChecking(true);
+    setStatus({ message: 'Checking your subscription…' });
+    async function refresh() {
+      try {
+        const response = await fetch('/api/v1/organization/billing/refresh', {
+          method: 'POST',
+          headers: { 'x-otakit-organization-id': organizationId },
+        });
+        if (cancelled) return;
+        if (response.status === 401) {
+          setStatus({ message: 'Sign in again to check your subscription.', signIn: true });
+          return;
+        }
+        if (response.status === 409) {
+          setStatus({
+            message:
+              'Your active workspace changed. Switch back in Settings to check this subscription.',
+            settings: true,
+          });
+          return;
+        }
+        if (!response.ok) throw new Error('Billing refresh failed');
+        const data = (await response.json()) as {
+          billing?: { isActive?: boolean; planKey?: string };
+        };
+        if (cancelled) return;
+        const plan = data.billing?.planKey;
+        if (data.billing?.isActive && (plan === 'starter' || plan === 'pro')) {
+          setStatus({
+            message: `${plan === 'pro' ? 'Pro' : 'Starter'} is active for this workspace. You’re ready to connect your app.`,
+          });
+          // Only remove the return marker after the server confirms the plan.
+          const current = new URL(window.location.href);
+          current.searchParams.delete('checkout');
+          current.searchParams.delete('checkout_org');
+          window.history.replaceState(window.history.state, '', current);
+        } else {
+          setStatus({
+            message:
+              'Your paid plan is not active yet. You can continue setting up your app and check again shortly.',
+            retry: true,
+          });
+        }
+      } catch {
+        if (!cancelled)
+          setStatus({
+            message: 'We couldn’t check your subscription. You can continue setup and retry here.',
+            retry: true,
+          });
+      } finally {
+        if (!cancelled) setChecking(false);
+      }
+    }
+    void refresh();
+    return () => {
+      cancelled = true;
+    };
+  }, [organizationId, attempt]);
+
+  if (!status) return null;
+  return (
+    <div className="border-b border-border">
+      <div className="mx-auto flex max-w-screen-xl flex-wrap items-center gap-3 px-6 py-4">
+        <p role="status" className="flex items-center gap-2 text-sm">
+          {checking && <LoaderCircle className="size-4 shrink-0 animate-spin" aria-hidden="true" />}
+          {status.message}
+        </p>
+        {status.retry && (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={checking}
+            onClick={() => setAttempt((value) => value + 1)}
+          >
+            Check again
+          </Button>
+        )}
+        {status.settings && (
+          <Link className="text-sm underline underline-offset-4" href="/dashboard/settings">
+            Open Settings
+          </Link>
+        )}
+        {status.signIn && (
+          <Link className="text-sm underline underline-offset-4" href="/login">
+            Sign in
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/console/app/components/CheckoutStatus.tsx
+++ b/packages/console/app/components/CheckoutStatus.tsx
@@ -25,49 +25,63 @@ export function CheckoutStatus({ organizationId }: { organizationId: string }) {
       return;
     }
     let cancelled = false;
+    const controller = new AbortController();
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let finishDelay: (() => void) | undefined;
     setChecking(true);
     setStatus({ message: 'Checking your subscription…' });
     async function refresh() {
       try {
-        const response = await fetch('/api/v1/organization/billing/refresh', {
-          method: 'POST',
-          headers: { 'x-otakit-organization-id': organizationId },
+        for (let check = 0; check < 3; check++) {
+          if (check > 0) {
+            await new Promise<void>((resolve) => {
+              finishDelay = resolve;
+              retryTimer = setTimeout(resolve, check * 1000);
+            });
+            finishDelay = undefined;
+          }
+          if (cancelled) return;
+          const response = await fetch('/api/v1/organization/billing/refresh', {
+            method: 'POST',
+            headers: { 'x-otakit-organization-id': organizationId },
+            signal: controller.signal,
+          });
+          if (cancelled) return;
+          if (response.status === 401) {
+            setStatus({ message: 'Sign in again to check your subscription.', signIn: true });
+            return;
+          }
+          if (response.status === 409) {
+            setStatus({
+              message:
+                'Your active workspace changed. Switch back in Settings to check this subscription.',
+              settings: true,
+            });
+            return;
+          }
+          if (!response.ok) throw new Error('Billing refresh failed');
+          const data = (await response.json()) as {
+            billing?: { isActive?: boolean; planKey?: string };
+          };
+          if (cancelled) return;
+          const plan = data.billing?.planKey;
+          if (data.billing?.isActive && (plan === 'starter' || plan === 'pro')) {
+            setStatus({
+              message: `${plan === 'pro' ? 'Pro' : 'Starter'} is active for this workspace. You’re ready to connect your app.`,
+            });
+            // Only remove the return marker after the server confirms the plan.
+            const current = new URL(window.location.href);
+            current.searchParams.delete('checkout');
+            current.searchParams.delete('checkout_org');
+            window.history.replaceState(window.history.state, '', current);
+            return;
+          }
+        }
+        setStatus({
+          message:
+            'Your paid plan is not active yet. You can continue setting up your app and check again shortly.',
+          retry: true,
         });
-        if (cancelled) return;
-        if (response.status === 401) {
-          setStatus({ message: 'Sign in again to check your subscription.', signIn: true });
-          return;
-        }
-        if (response.status === 409) {
-          setStatus({
-            message:
-              'Your active workspace changed. Switch back in Settings to check this subscription.',
-            settings: true,
-          });
-          return;
-        }
-        if (!response.ok) throw new Error('Billing refresh failed');
-        const data = (await response.json()) as {
-          billing?: { isActive?: boolean; planKey?: string };
-        };
-        if (cancelled) return;
-        const plan = data.billing?.planKey;
-        if (data.billing?.isActive && (plan === 'starter' || plan === 'pro')) {
-          setStatus({
-            message: `${plan === 'pro' ? 'Pro' : 'Starter'} is active for this workspace. You’re ready to connect your app.`,
-          });
-          // Only remove the return marker after the server confirms the plan.
-          const current = new URL(window.location.href);
-          current.searchParams.delete('checkout');
-          current.searchParams.delete('checkout_org');
-          window.history.replaceState(window.history.state, '', current);
-        } else {
-          setStatus({
-            message:
-              'Your paid plan is not active yet. You can continue setting up your app and check again shortly.',
-            retry: true,
-          });
-        }
       } catch {
         if (!cancelled)
           setStatus({
@@ -81,6 +95,9 @@ export function CheckoutStatus({ organizationId }: { organizationId: string }) {
     void refresh();
     return () => {
       cancelled = true;
+      controller.abort();
+      clearTimeout(retryTimer);
+      finishDelay?.();
     };
   }, [organizationId, attempt]);
 

--- a/packages/console/app/components/PricingDialog.tsx
+++ b/packages/console/app/components/PricingDialog.tsx
@@ -323,7 +323,7 @@ export function PricingDialog({
   );
 }
 
-function PlanCard({
+export function PlanCard({
   name,
   price,
   priceNote,

--- a/packages/console/app/components/ProductDashboard.tsx
+++ b/packages/console/app/components/ProductDashboard.tsx
@@ -34,6 +34,7 @@ import { toast } from 'sonner';
 import { DashboardHeader } from '@/app/components/DashboardHeader';
 import { PricingDialog, type PricingDialogBillingData } from '@/app/components/PricingDialog';
 import { trackConversion } from '@/lib/gtag';
+import { appIdentifierError } from '@/lib/onboarding-profile';
 import type {
   ApiError,
   AppSummary,
@@ -508,6 +509,7 @@ export function ProductDashboard({
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newAppSlug, setNewAppSlug] = useState('');
   const [creatingApp, setCreatingApp] = useState(false);
+  const [createAppError, setCreateAppError] = useState<string | null>(null);
 
   // Messages (via toast)
 
@@ -1029,8 +1031,14 @@ export function ProductDashboard({
   }
 
   async function createApp() {
+    if (creatingApp) return;
     const slug = newAppSlug.trim();
-    if (!slug) return toast.error('App slug is required');
+    const validation = appIdentifierError(slug);
+    if (validation) {
+      setCreateAppError(validation);
+      return;
+    }
+    setCreateAppError(null);
     setCreatingApp(true);
     toast.dismiss();
     try {
@@ -1040,15 +1048,17 @@ export function ProductDashboard({
         body: JSON.stringify({ slug }),
       });
       const data = await parseJson<ApiError & { id?: string }>(res);
-      if (!res.ok) throw new Error(data.error ?? 'Failed to create app');
+      if (!res.ok) throw new Error(data.error ?? 'Couldn’t register your app. Please try again.');
       setCreateDialogOpen(false);
       setNewAppSlug('');
       if (data.id) setSelectedAppId(data.id);
-      toast.success('App created');
+      toast.success('App registered. Install the updater to finish connecting it.');
       trackConversion('app_created');
       router.refresh();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to create app');
+      setCreateAppError(
+        err instanceof Error ? err.message : 'Couldn’t register your app. Please try again.',
+      );
     } finally {
       setCreatingApp(false);
     }
@@ -1110,7 +1120,7 @@ export function ProductDashboard({
                         <SelectItem value="__new_app__" className="text-muted-foreground">
                           <span className="flex items-center gap-1.5">
                             <Plus className="size-3.5" />
-                            New app
+                            Connect app
                           </span>
                         </SelectItem>
                       </SelectContent>
@@ -1152,7 +1162,7 @@ export function ProductDashboard({
                     onClick={() => setCreateDialogOpen(true)}
                   >
                     <Plus className="size-3.5" />
-                    New app
+                    Connect app
                   </Button>
                 )}
               </div>
@@ -1175,17 +1185,15 @@ export function ProductDashboard({
                     <div className="p-5">
                       <div className="rounded-lg border border-dashed border-border py-12 text-center">
                         <Cpu className="mx-auto size-6 text-muted-foreground/40" />
-                        <p className="mt-3 text-sm font-medium">No apps yet</p>
+                        <p className="mt-3 text-sm font-medium">Connect your first app</p>
                         <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
-                          Create an app here or register one with the CLI using{' '}
-                          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
-                            otakit register --slug com.example.app
-                          </code>
+                          Register your Capacitor app, install the updater, and send your first
+                          update to a test device. You can start before your app is in the stores.
                         </p>
                         <div className="mt-5">
                           <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
                             <Plus className="size-3.5" />
-                            Create app
+                            Connect your app
                           </Button>
                         </div>
                         <p className="mt-4">
@@ -2300,45 +2308,88 @@ export function ProductDashboard({
         </DialogContent>
       </Dialog>
 
-      {/* Create App Dialog */}
-      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+      {/* Connect App Dialog */}
+      <Dialog
+        open={createDialogOpen}
+        onOpenChange={(open) => {
+          if (!creatingApp) {
+            setCreateDialogOpen(open);
+            setCreateAppError(null);
+          }
+        }}
+      >
         <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Cpu className="size-4" />
-              Create app
-            </DialogTitle>
-            <DialogDescription>
-              Choose a stable identifier, e.g. <code className="text-xs">com.example.mobile</code>
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-2">
-            <Label htmlFor="new-app-slug">App slug</Label>
-            <Input
-              id="new-app-slug"
-              placeholder="com.example.mobile"
-              value={newAppSlug}
-              onChange={(e) => setNewAppSlug(e.target.value)}
-            />
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setCreateDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={createApp} disabled={creatingApp}>
-              {creatingApp ? (
-                <>
-                  <LoaderCircle className="size-3.5 animate-spin" />
-                  Creating...
-                </>
-              ) : (
-                <>
-                  <Plus className="size-3.5" />
-                  Create
-                </>
-              )}
-            </Button>
-          </DialogFooter>
+          <form
+            className="space-y-5"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void createApp();
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Cpu className="size-4" />
+                Connect your app
+              </DialogTitle>
+              <DialogDescription>
+                Register your Capacitor app in OtaKit. Then install the updater in your project to
+                start receiving updates.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2">
+              <Label htmlFor="new-app-slug">App identifier</Label>
+              <Input
+                id="new-app-slug"
+                placeholder="my-app"
+                autoComplete="off"
+                autoCapitalize="none"
+                spellCheck={false}
+                maxLength={120}
+                disabled={creatingApp}
+                aria-describedby="new-app-help new-app-error"
+                aria-invalid={Boolean(createAppError)}
+                value={newAppSlug}
+                onChange={(e) => {
+                  setNewAppSlug(e.target.value);
+                  setCreateAppError(null);
+                }}
+              />
+              <p id="new-app-help" className="text-sm leading-6 text-muted-foreground">
+                Any unique label in this workspace works, such as <code>my-app</code>. It does not
+                need to match your native app ID. Use 3–120 letters, numbers, dots, underscores, or
+                hyphens.
+              </p>
+              <p id="new-app-error" role="alert" className="text-sm text-destructive">
+                {createAppError}
+              </p>
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={creatingApp}
+                onClick={() => {
+                  setCreateDialogOpen(false);
+                  setCreateAppError(null);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={creatingApp}>
+                {creatingApp ? (
+                  <>
+                    <LoaderCircle className="size-3.5 animate-spin" />
+                    Connecting...
+                  </>
+                ) : (
+                  <>
+                    <Plus className="size-3.5" />
+                    Connect your app
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
         </DialogContent>
       </Dialog>
     </div>

--- a/packages/console/app/components/ProductDashboard.tsx
+++ b/packages/console/app/components/ProductDashboard.tsx
@@ -35,6 +35,7 @@ import { DashboardHeader } from '@/app/components/DashboardHeader';
 import { PricingDialog, type PricingDialogBillingData } from '@/app/components/PricingDialog';
 import { trackConversion } from '@/lib/gtag';
 import { appIdentifierError } from '@/lib/onboarding-profile';
+import { CheckoutStatus } from '@/app/components/CheckoutStatus';
 import type {
   ApiError,
   AppSummary,
@@ -1082,6 +1083,10 @@ export function ProductDashboard({
         </div>
         <div className="relative flex min-h-[calc(100vh-3.5rem)] flex-col">
           {/* Messages handled by sonner toast */}
+          <CheckoutStatus
+            key={initialData.activeOrganization.id}
+            organizationId={initialData.activeOrganization.id}
+          />
 
           {/* App selector bar */}
           <section className="border-b border-border">

--- a/packages/console/app/components/SignupTracker.tsx
+++ b/packages/console/app/components/SignupTracker.tsx
@@ -8,7 +8,7 @@ import { trackConversion } from '@/lib/gtag';
 // storage or sign in on a new device.
 const SIGNUP_WINDOW_MS = 30 * 60 * 1000;
 
-// Fires the sign_up conversion exactly once per user, on the first dashboard
+// Fires the sign_up conversion exactly once per user, on the first console
 // visit after account creation. Client-side because the Google tag (and the
 // ad-click cookies it needs) only exist in the browser.
 export function SignupTracker({ userId, createdAt }: { userId: string; createdAt: string }) {

--- a/packages/console/app/components/setup/SetupLauncher.tsx
+++ b/packages/console/app/components/setup/SetupLauncher.tsx
@@ -40,7 +40,7 @@ function ProgressBar({ pct, blocked }: { pct: number; blocked: boolean }) {
  *
  * It removes itself for good once the first update lands.
  */
-export function SetupLauncher() {
+export function SetupLauncher({ openOnEmpty = true }: { openOnEmpty?: boolean }) {
   const { snapshot, hidden, dismiss } = useSetupStatus();
   const [choice, setChoice] = useState<boolean | null>(null);
 
@@ -49,7 +49,7 @@ export function SetupLauncher() {
   // first step lands, and the panel must not slam shut while it is being used.
   const [autoOpen, setAutoOpen] = useState<boolean | null>(null);
   if (snapshot && autoOpen === null) {
-    setAutoOpen(snapshot.completedCount === 0);
+    setAutoOpen(openOnEmpty && snapshot.completedCount === 0);
   }
 
   const open = choice ?? autoOpen === true;

--- a/packages/console/app/components/setup/content.ts
+++ b/packages/console/app/components/setup/content.ts
@@ -8,7 +8,7 @@ export const STEP_ORDER: StepId[] = ['app', 'bundle', 'release', 'device'];
 
 /** One or two words. This is what the header indicator shows. */
 export const SHORT_LABEL: Record<StepId, string> = {
-  app: 'Create app',
+  app: 'Connect app',
   bundle: 'Upload bundle',
   release: 'Publish',
   device: 'Awaiting device',
@@ -100,7 +100,7 @@ export function connectSummary(choice: SetupChoice): string {
 
 const AGENT_STEPS: Record<StepId, StepContent> = {
   app: {
-    title: 'Create your app',
+    title: 'Connect your app',
     hint: 'Registers it, wires the Capacitor plugin, sets the app ID.',
     action: {
       kind: 'prompt',
@@ -132,7 +132,7 @@ const AGENT_STEPS: Record<StepId, StepContent> = {
 
 const CLI_STEPS: Record<StepId, StepContent> = {
   app: {
-    title: 'Create your app',
+    title: 'Connect your app',
     hint: 'Then put the app ID in plugins.OtaKit.appId.',
     action: { kind: 'command', text: 'otakit register --slug com.example.app' },
   },

--- a/packages/console/app/components/setup/content.ts
+++ b/packages/console/app/components/setup/content.ts
@@ -104,7 +104,7 @@ const AGENT_STEPS: Record<StepId, StepContent> = {
     hint: 'Registers it, wires the Capacitor plugin, sets the app ID.',
     action: {
       kind: 'prompt',
-      text: 'Set up OtaKit in this project: create the app in my OtaKit organization, install and configure the Capacitor plugin, and make sure notifyAppReady() is called once the app has finished booting.',
+      text: 'Set up OtaKit in this project: register the app in my OtaKit workspace, install and configure the Capacitor plugin using the generated OtaKit app ID, and make sure notifyAppReady() is called once the app has finished booting.',
     },
   },
   bundle: {
@@ -134,7 +134,7 @@ const CLI_STEPS: Record<StepId, StepContent> = {
   app: {
     title: 'Connect your app',
     hint: 'Then put the app ID in plugins.OtaKit.appId.',
-    action: { kind: 'command', text: 'otakit register --slug com.example.app' },
+    action: { kind: 'command', text: 'otakit register --slug my-app' },
   },
   bundle: {
     title: 'Upload a bundle',

--- a/packages/console/app/dashboard/data.ts
+++ b/packages/console/app/dashboard/data.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { cache } from 'react';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
@@ -86,7 +87,7 @@ async function getOrganizationData(organizationId: string) {
   };
 }
 
-export async function getDashboardInitialData(): Promise<DashboardInitialData> {
+export const getDashboardInitialData = cache(async (): Promise<DashboardInitialData> => {
   const { session, memberships, activeMembership } = await getUserContext();
   const organizationData = await getOrganizationData(activeMembership.organizationId);
 
@@ -127,4 +128,4 @@ export async function getDashboardInitialData(): Promise<DashboardInitialData> {
     analyticsEnabled: isTinybirdConfigured(),
     remoteMcpOAuthEnabled: isRemoteMcpOAuthEnabled(),
   };
-}
+});

--- a/packages/console/app/dashboard/layout.tsx
+++ b/packages/console/app/dashboard/layout.tsx
@@ -1,14 +1,23 @@
 import type { ReactNode } from 'react';
+import { redirect } from 'next/navigation';
 
 import { DashboardDataProvider } from '@/app/dashboard/DashboardDataProvider';
 import { getDashboardInitialData } from '@/app/dashboard/data';
 import { SignupTracker } from '@/app/components/SignupTracker';
 import { SetupStatusProvider } from '@/app/components/setup/SetupStatusProvider';
+import { getOnboardingProfile } from '@/lib/services/onboarding-profile';
+import { shouldShowOnboarding } from '@/lib/onboarding-profile';
 
 export const dynamic = 'force-dynamic';
 
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
   const initialData = await getDashboardInitialData();
+  if (initialData.apps.length === 0 && initialData.activeOrganization.role === 'owner') {
+    const profile = await getOnboardingProfile(initialData.activeOrganization.id);
+    if (shouldShowOnboarding({ appCount: 0, role: initialData.activeOrganization.role, profile })) {
+      redirect('/onboarding');
+    }
+  }
 
   return (
     <DashboardDataProvider initialData={initialData}>

--- a/packages/console/app/dashboard/layout.tsx
+++ b/packages/console/app/dashboard/layout.tsx
@@ -14,7 +14,15 @@ export default async function DashboardLayout({ children }: { children: ReactNod
   const initialData = await getDashboardInitialData();
   if (initialData.apps.length === 0 && initialData.activeOrganization.role === 'owner') {
     const profile = await getOnboardingProfile(initialData.activeOrganization.id);
-    if (shouldShowOnboarding({ appCount: 0, role: initialData.activeOrganization.role, profile })) {
+    // Business onboarding ends when the questions are completed or skipped.
+    // Connecting an app is a separate flow in the dashboard's setup panel.
+    if (
+      shouldShowOnboarding({
+        appCount: initialData.apps.length,
+        role: initialData.activeOrganization.role,
+        profile,
+      })
+    ) {
       redirect('/onboarding');
     }
   }

--- a/packages/console/app/dashboard/layout.tsx
+++ b/packages/console/app/dashboard/layout.tsx
@@ -1,32 +1,14 @@
 import type { ReactNode } from 'react';
-import { redirect } from 'next/navigation';
 
 import { DashboardDataProvider } from '@/app/dashboard/DashboardDataProvider';
 import { getDashboardInitialData } from '@/app/dashboard/data';
 import { SignupTracker } from '@/app/components/SignupTracker';
 import { SetupStatusProvider } from '@/app/components/setup/SetupStatusProvider';
-import { getOnboardingProfile } from '@/lib/services/onboarding-profile';
-import { shouldShowOnboarding } from '@/lib/onboarding-profile';
 
 export const dynamic = 'force-dynamic';
 
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
   const initialData = await getDashboardInitialData();
-  if (initialData.apps.length === 0 && initialData.activeOrganization.role === 'owner') {
-    const profile = await getOnboardingProfile(initialData.activeOrganization.id);
-    // Business onboarding ends when the questions are completed or skipped.
-    // Connecting an app is a separate flow in the dashboard's setup panel.
-    if (
-      shouldShowOnboarding({
-        appCount: initialData.apps.length,
-        role: initialData.activeOrganization.role,
-        profile,
-      })
-    ) {
-      redirect('/onboarding');
-    }
-  }
-
   return (
     <DashboardDataProvider initialData={initialData}>
       <SignupTracker userId={initialData.user.id} createdAt={initialData.user.createdAt} />

--- a/packages/console/app/dashboard/page.tsx
+++ b/packages/console/app/dashboard/page.tsx
@@ -1,16 +1,42 @@
-'use client';
+import { redirect } from 'next/navigation';
 
 import { ProductDashboard } from '@/app/components/ProductDashboard';
 import { SetupLauncher } from '@/app/components/setup/SetupLauncher';
-import { useDashboardData } from '@/app/dashboard/DashboardDataProvider';
+import { getDashboardInitialData } from '@/app/dashboard/data';
+import { getOnboardingProfile } from '@/lib/services/onboarding-profile';
+import { shouldShowOnboarding } from '@/lib/onboarding-profile';
 
-export default function DashboardPage() {
-  const initialData = useDashboardData();
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ pricing?: string; checkout?: string }>;
+}) {
+  const [initialData, params] = await Promise.all([getDashboardInitialData(), searchParams]);
+  // Only intercept the app dashboard. Settings and explicit billing links must
+  // stay reachable while the business questionnaire is unfinished.
+  const billingVisit =
+    params.pricing === '1' || ['success', 'onboarding'].includes(params.checkout ?? '');
+  if (
+    !billingVisit &&
+    initialData.apps.length === 0 &&
+    initialData.activeOrganization.role === 'owner'
+  ) {
+    const profile = await getOnboardingProfile(initialData.activeOrganization.id);
+    if (
+      shouldShowOnboarding({
+        appCount: initialData.apps.length,
+        role: initialData.activeOrganization.role,
+        profile,
+      })
+    ) {
+      redirect('/onboarding');
+    }
+  }
   return (
     <>
       <ProductDashboard initialData={initialData} />
       {/* Only on the apps view: Settings already has a launcher in this corner. */}
-      <SetupLauncher />
+      <SetupLauncher openOnEmpty={params.checkout !== 'onboarding'} />
     </>
   );
 }

--- a/packages/console/app/dashboard/page.tsx
+++ b/packages/console/app/dashboard/page.tsx
@@ -9,13 +9,14 @@ import { shouldShowOnboarding } from '@/lib/onboarding-profile';
 export default async function DashboardPage({
   searchParams,
 }: {
-  searchParams: Promise<{ pricing?: string; checkout?: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const [initialData, params] = await Promise.all([getDashboardInitialData(), searchParams]);
+  const pricing = Array.isArray(params.pricing) ? params.pricing[0] : params.pricing;
+  const checkout = Array.isArray(params.checkout) ? params.checkout[0] : params.checkout;
   // Only intercept the app dashboard. Settings and explicit billing links must
   // stay reachable while the business questionnaire is unfinished.
-  const billingVisit =
-    params.pricing === '1' || ['success', 'onboarding'].includes(params.checkout ?? '');
+  const billingVisit = pricing === '1' || ['success', 'onboarding'].includes(checkout ?? '');
   if (
     !billingVisit &&
     initialData.apps.length === 0 &&
@@ -36,7 +37,7 @@ export default async function DashboardPage({
     <>
       <ProductDashboard initialData={initialData} />
       {/* Only on the apps view: Settings already has a launcher in this corner. */}
-      <SetupLauncher openOnEmpty={params.checkout !== 'onboarding'} />
+      <SetupLauncher openOnEmpty={checkout !== 'onboarding'} />
     </>
   );
 }

--- a/packages/console/app/login/LoginPageClient.tsx
+++ b/packages/console/app/login/LoginPageClient.tsx
@@ -212,10 +212,10 @@ export function LoginPageClient({
     try {
       const { data, error: signInError } = await authClient.signIn.social({
         provider,
-        // A pending MCP authorization outranks the dashboard for both new and
-        // returning users; otherwise this is unchanged.
+        // MCP authorization takes priority. Otherwise the dashboard resumes
+        // onboarding only for owners of an unfinished, empty workspace.
         callbackURL: authorizationPath ?? '/dashboard',
-        newUserCallbackURL: authorizationPath ?? '/dashboard?pricing=1',
+        newUserCallbackURL: authorizationPath ?? '/dashboard',
         errorCallbackURL: '/login',
         disableRedirect: true,
       });
@@ -303,13 +303,8 @@ export function LoginPageClient({
           return;
         }
 
-        // Both timestamps come from the server, so this never depends on the
-        // browser clock: a freshly inserted user still has updatedAt === createdAt.
-        const isNewUser =
-          typeof data?.user?.createdAt !== 'undefined' &&
-          String(data.user.createdAt) === String(data.user.updatedAt);
-
-        window.location.href = isNewUser ? '/dashboard?pricing=1' : '/dashboard';
+        // The dashboard checks workspace progress and resumes onboarding when needed.
+        window.location.href = '/dashboard';
       } catch (cause) {
         submittedCode.current = null;
         setError(cause instanceof Error ? cause.message : 'Invalid code');

--- a/packages/console/app/onboard/page.tsx
+++ b/packages/console/app/onboard/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function OnboardPage() {
+  redirect('/onboarding');
+}

--- a/packages/console/app/onboarding/OnboardingFlow.tsx
+++ b/packages/console/app/onboarding/OnboardingFlow.tsx
@@ -17,6 +17,7 @@ import {
   isUnsupportedTechnology,
   onboardingAnswersSchema,
   onboardingStepError,
+  onboardingUsageError,
   type OnboardingAnswers,
   type OnboardingProfile,
   type OnboardingRequest,
@@ -64,6 +65,8 @@ export function OnboardingFlow({
   const [step, setStep] = useState<OnboardingStep>(initialProfile?.step ?? 'app');
   const [completed, setCompleted] = useState(Boolean(initialProfile?.completedAt));
   const [busy, setBusy] = useState(false);
+  const [checkingOut, setCheckingOut] = useState<'starter' | 'pro' | null>(null);
+  const [invalidField, setInvalidField] = useState<'activeUsers' | 'updatesPerMonth' | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [sessionExpired, setSessionExpired] = useState(false);
   const busyRef = useRef(false);
@@ -86,6 +89,7 @@ export function OnboardingFlow({
   function update(patch: Partial<OnboardingAnswers>) {
     setAnswers((current) => ({ ...current, ...patch }));
     setError(null);
+    setInvalidField(null);
   }
   async function save(input: OnboardingRequest) {
     const response = await fetch('/api/v1/organization/onboarding/profile', {
@@ -123,26 +127,32 @@ export function OnboardingFlow({
     }
   }
   async function checkout(plan: 'starter' | 'pro', interval: 'month' | 'year') {
-    const response = await fetch('/api/v1/organization/billing/checkout', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'x-otakit-organization-id': organizationId },
-      body: JSON.stringify({ planKey: plan, interval, returnTo: 'dashboard' }),
-    });
-    const data = (await response.json().catch(() => null)) as {
-      checkoutUrl?: string;
-      error?: string;
-    } | null;
-    if (response.status === 401) setSessionExpired(true);
-    if (!response.ok || !data?.checkoutUrl)
-      throw new Error(
-        `${data?.error ?? 'Checkout couldn’t start.'} Your answers are saved. Try again or continue to the dashboard on your current plan.`,
-      );
-    window.location.assign(data.checkoutUrl);
+    setCheckingOut(plan);
+    try {
+      const response = await fetch('/api/v1/organization/billing/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-otakit-organization-id': organizationId },
+        body: JSON.stringify({ planKey: plan, interval, returnTo: 'dashboard' }),
+      });
+      const data = (await response.json().catch(() => null)) as {
+        checkoutUrl?: string;
+        error?: string;
+      } | null;
+      if (response.status === 401) setSessionExpired(true);
+      if (!response.ok || !data?.checkoutUrl)
+        throw new Error(
+          `${data?.error ?? 'Checkout couldn’t start.'} Your answers are saved. Try again or continue to the dashboard on your current plan.`,
+        );
+      window.location.assign(data.checkoutUrl);
+    } finally {
+      setCheckingOut(null);
+    }
   }
   function next() {
     if (step === 'plans') return;
     const validation = onboardingStepError(answers, step);
     if (validation) {
+      setInvalidField(step === 'audience' ? (onboardingUsageError(answers)?.field ?? null) : null);
       setError(validation);
       return;
     }
@@ -231,6 +241,7 @@ export function OnboardingFlow({
         </p>
         {error && (
           <p
+            id="onboarding-error"
             ref={errorRef}
             tabIndex={-1}
             role="alert"
@@ -245,6 +256,7 @@ export function OnboardingFlow({
           </p>
         )}
         <form
+          noValidate
           className="mt-8"
           onSubmit={(event) => {
             event.preventDefault();
@@ -388,6 +400,16 @@ export function OnboardingFlow({
                     </p>
                   </Notice>
                 )}
+                {answers.otaProvider === 'none' && (
+                  <Notice>
+                    <strong>Start with a native test build.</strong>
+                    <p className="mt-2">
+                      A device receives OtaKit updates once its native build includes the plugin.
+                      Test locally first. To reach existing users, ship one store build with the
+                      plugin.
+                    </p>
+                  </Notice>
+                )}
               </>
             )}
 
@@ -396,19 +418,21 @@ export function OnboardingFlow({
                 <UsageInput
                   id="active-users"
                   label="Monthly active users"
-                  hint="People who open your app in a typical month. Enter 0 if you haven’t launched."
+                  hint="People who open your app in a typical month. Enter 0 if you haven’t launched, or leave blank if you’re not sure."
                   placeholder="e.g. 1000"
                   value={answers.activeUsers}
                   max={1_000_000_000}
+                  invalid={invalidField === 'activeUsers'}
                   onChange={(value) => update({ activeUsers: value })}
                 />
                 <UsageInput
                   id="updates-month"
                   label="OTA updates you expect to ship each month"
-                  hint="A rough estimate helps translate your audience into downloaded updates."
+                  hint="A rough estimate helps compare plans. Leave blank if you’re not sure."
                   placeholder="e.g. 4"
                   value={answers.updatesPerMonth}
                   max={1_000}
+                  invalid={invalidField === 'updatesPerMonth'}
                   onChange={(value) => update({ updatesPerMonth: value })}
                 />
                 <div className="space-y-2">
@@ -489,11 +513,14 @@ export function OnboardingFlow({
                       <div className="rounded-xl border p-6">
                         <h2 className="text-lg font-medium">
                           Your workspace already has{' '}
-                          {currentPlan === 'pro'
-                            ? 'Pro'
-                            : currentPlan === 'starter'
-                              ? 'Starter'
-                              : 'Enterprise'}
+                          {
+                            {
+                              free: 'Free',
+                              starter: 'Starter',
+                              pro: 'Pro',
+                              enterprise: 'Enterprise',
+                            }[currentPlan]
+                          }
                           .
                         </h2>
                         <p className="mt-2 text-sm text-muted-foreground">
@@ -524,6 +551,11 @@ export function OnboardingFlow({
                             actionIcon={Leaf}
                             disabled={busy}
                             onAction={goToDashboard}
+                            tag={
+                              estimatedDownloads !== null && estimatedDownloads <= freeDownloads
+                                ? 'Fits your estimate'
+                                : undefined
+                            }
                             highlighted={
                               estimatedDownloads !== null && estimatedDownloads <= freeDownloads
                             }
@@ -545,6 +577,14 @@ export function OnboardingFlow({
                             }
                             actionIcon={Rocket}
                             disabled={busy || !billingEnabled || freeDownloads >= 100_000}
+                            loading={checkingOut === 'starter'}
+                            tag={
+                              estimatedDownloads !== null &&
+                              estimatedDownloads > freeDownloads &&
+                              estimatedDownloads <= 100_000
+                                ? 'Fits your estimate'
+                                : undefined
+                            }
                             onAction={() => void run(() => checkout('starter', 'month'))}
                             highlighted={
                               estimatedDownloads !== null &&
@@ -567,6 +607,14 @@ export function OnboardingFlow({
                             actionLabel="Choose Pro"
                             actionIcon={Star}
                             disabled={busy || !billingEnabled}
+                            loading={checkingOut === 'pro'}
+                            tag={
+                              estimatedDownloads !== null &&
+                              estimatedDownloads > 100_000 &&
+                              estimatedDownloads <= 1_000_000
+                                ? 'Fits your estimate'
+                                : undefined
+                            }
                             actionItems={[
                               {
                                 label: 'Yearly',
@@ -580,7 +628,9 @@ export function OnboardingFlow({
                               },
                             ]}
                             highlighted={
-                              estimatedDownloads !== null && estimatedDownloads > 100_000
+                              estimatedDownloads !== null &&
+                              estimatedDownloads > 100_000 &&
+                              estimatedDownloads <= 1_000_000
                             }
                           />
                           <PlanCard
@@ -597,6 +647,14 @@ export function OnboardingFlow({
                             current={false}
                             actionLabel="Contact sales"
                             actionIcon={Building2}
+                            highlighted={
+                              estimatedDownloads !== null && estimatedDownloads > 1_000_000
+                            }
+                            tag={
+                              estimatedDownloads !== null && estimatedDownloads > 1_000_000
+                                ? 'Discuss your volume'
+                                : undefined
+                            }
                             disabled={busy || !billingEnabled}
                             onAction={() => {
                               window.location.href = `${SUPPORT_MAILTO}?subject=OtaKit%20Enterprise`;
@@ -607,6 +665,13 @@ export function OnboardingFlow({
                           Free and Starter stop serving updates at their included limits. Pro
                           overage is optional. Choosing a paid plan opens checkout. You can also
                           continue with Free and upgrade later.
+                          {estimatedDownloads !== null && estimatedDownloads > 1_000_000 && (
+                            <>
+                              {' '}
+                              Your estimate exceeds Pro’s included volume. You can enable paid
+                              overage on Pro or contact us about Enterprise.
+                            </>
+                          )}
                         </p>
                       </>
                     )}
@@ -624,6 +689,7 @@ export function OnboardingFlow({
                   disabled={busy}
                   onClick={() => {
                     setError(null);
+                    setInvalidField(null);
                     setStep(ONBOARDING_STEPS[index - 1]);
                   }}
                 >
@@ -631,9 +697,21 @@ export function OnboardingFlow({
                   Back
                 </Button>
               ) : (
-                <span className="text-xs text-muted-foreground">
+                <span className="hidden text-xs text-muted-foreground sm:inline">
                   Progress saves when you continue.
                 </span>
+              )}
+              {!unsupported && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="ml-auto sm:hidden"
+                  disabled={busy}
+                  onClick={skip}
+                >
+                  Skip for now
+                </Button>
               )}
               <Button
                 type="submit"
@@ -725,6 +803,7 @@ function UsageInput({
   placeholder,
   value,
   max,
+  invalid,
   onChange,
 }: {
   id: string;
@@ -733,11 +812,14 @@ function UsageInput({
   placeholder: string;
   value: number | null | undefined;
   max: number;
+  invalid: boolean;
   onChange: (value: number | null | undefined) => void;
 }) {
   return (
     <div className="space-y-3">
-      <Label htmlFor={id}>{label}</Label>
+      <Label htmlFor={id}>
+        {label} <span className="text-muted-foreground">(optional)</span>
+      </Label>
       <p id={`${id}-hint`} className="text-sm text-muted-foreground">
         {hint}
       </p>
@@ -752,20 +834,12 @@ function UsageInput({
           step={1}
           placeholder={placeholder}
           value={value ?? ''}
-          aria-describedby={`${id}-hint`}
+          aria-invalid={invalid || undefined}
+          aria-describedby={`${id}-hint${invalid ? ' onboarding-error' : ''}`}
           onChange={(event) =>
             onChange(event.target.value === '' ? undefined : Number(event.target.value))
           }
         />
-        <label className="flex cursor-pointer items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            className="size-4 accent-foreground"
-            checked={value === null}
-            onChange={(event) => onChange(event.target.checked ? null : undefined)}
-          />
-          Not sure yet
-        </label>
       </div>
     </div>
   );

--- a/packages/console/app/onboarding/OnboardingFlow.tsx
+++ b/packages/console/app/onboarding/OnboardingFlow.tsx
@@ -3,27 +3,16 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
-import {
-  ArrowLeft,
-  ArrowRight,
-  Building2,
-  Check,
-  Copy,
-  Leaf,
-  LoaderCircle,
-  Rocket,
-  Star,
-} from 'lucide-react';
+import { ArrowLeft, ArrowRight, Building2, Leaf, LoaderCircle, Rocket, Star } from 'lucide-react';
 
 import { PlanCard, type PlanKey } from '@/app/components/PricingDialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { SUPPORT_MAILTO } from '@/lib/support';
-import { trackConversion } from '@/lib/gtag';
 import {
+  ONBOARDING_QUESTIONS,
   ONBOARDING_STEPS,
-  appIdentifierError,
   estimateMonthlyDownloads,
   isUnsupportedTechnology,
   onboardingStepError,
@@ -33,15 +22,15 @@ import {
   type OnboardingStep,
 } from '@/lib/onboarding-profile';
 
-const STEP_LABELS = ['Your app', 'Updates', 'Audience', 'Plan', 'Connect'];
+const STEP_LABELS = ['Your app', 'Updates', 'Audience', 'Pricing'];
 const TITLES: Record<OnboardingStep, [string, string]> = {
   app: [
-    'Let’s start with your app.',
-    'A few details will help us show you the right setup and pricing.',
+    'Tell us about your app.',
+    'A few questions about your app and goals. Then compare plans and explore the dashboard.',
   ],
   updates: [
-    'How do you ship updates today?',
-    'We’ll use this to guide your first release or migration.',
+    'What do you need from OTA updates?',
+    'Tell us about your current setup and what you want to improve.',
   ],
   audience: [
     'How many people use your app?',
@@ -49,11 +38,7 @@ const TITLES: Record<OnboardingStep, [string, string]> = {
   ],
   plans: [
     'Choose your starting plan.',
-    'Every plan includes unlimited apps and updates. Usage is measured by downloaded updates.',
-  ],
-  connect: [
-    'Connect your app to OtaKit.',
-    'First, give it an identifier. Then install the plugin in your project.',
+    'Your answers are saved. Every plan includes unlimited apps and updates; usage is measured by downloaded updates.',
   ],
 };
 
@@ -76,41 +61,31 @@ export function OnboardingFlow({
 }) {
   const [answers, setAnswers] = useState<OnboardingAnswers>(initialProfile?.answers ?? {});
   const [step, setStep] = useState<OnboardingStep>(initialProfile?.step ?? 'app');
-  const [connectedApp, setConnectedApp] = useState(initialProfile?.connectedApp ?? null);
-  const [slug, setSlug] = useState('');
+  const [completed, setCompleted] = useState(Boolean(initialProfile?.completedAt));
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [sessionExpired, setSessionExpired] = useState(false);
-  const [checkoutReturned, setCheckoutReturned] = useState(false);
   const busyRef = useRef(false);
   const heading = useRef<HTMLHeadingElement>(null);
   const errorRef = useRef<HTMLParagraphElement>(null);
   const index = ONBOARDING_STEPS.indexOf(step);
   const unsupported = isUnsupportedTechnology(answers.technology);
   const estimatedDownloads = estimateMonthlyDownloads(answers);
-  const needsCheckout =
-    billingEnabled &&
-    !hasSubscription &&
-    (answers.selectedPlan === 'starter' || answers.selectedPlan === 'pro');
-  const dashboardHref = connectedApp
-    ? `/dashboard?app=${encodeURIComponent(connectedApp.id)}`
-    : '/dashboard';
 
   useEffect(() => {
     heading.current?.focus();
-  }, [step, connectedApp]);
+  }, [step]);
   useEffect(() => {
     if (error) errorRef.current?.focus();
   }, [error]);
-  useEffect(() => {
-    setCheckoutReturned(new URLSearchParams(window.location.search).get('checkout') === 'success');
-  }, []);
 
+  function goToDashboard() {
+    window.location.assign('/dashboard');
+  }
   function update(patch: Partial<OnboardingAnswers>) {
     setAnswers((current) => ({ ...current, ...patch }));
     setError(null);
   }
-
   async function save(input: OnboardingRequest) {
     const response = await fetch('/api/v1/organization/onboarding/profile', {
       method: 'POST',
@@ -124,14 +99,13 @@ export function OnboardingFlow({
       );
     }
     const data = (await response.json().catch(() => null)) as {
-      profile?: OnboardingProfile & { appCreated?: boolean };
+      profile?: OnboardingProfile;
       error?: string;
     } | null;
     if (!response.ok || !data?.profile)
       throw new Error(data?.error ?? 'We couldn’t save your progress. Please try again.');
     return data.profile;
   }
-
   async function run(action: () => Promise<void>) {
     if (busyRef.current) return;
     busyRef.current = true;
@@ -147,16 +121,11 @@ export function OnboardingFlow({
       setBusy(false);
     }
   }
-
-  async function checkout(plan: OnboardingAnswers['selectedPlan'] = answers.selectedPlan) {
+  async function checkout(plan: 'starter' | 'pro', interval: 'month' | 'year') {
     const response = await fetch('/api/v1/organization/billing/checkout', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'x-otakit-organization-id': organizationId },
-      body: JSON.stringify({
-        planKey: plan,
-        interval: answers.billingInterval ?? 'month',
-        returnTo: 'onboarding',
-      }),
+      body: JSON.stringify({ planKey: plan, interval, returnTo: 'dashboard' }),
     });
     const data = (await response.json().catch(() => null)) as {
       checkoutUrl?: string;
@@ -165,72 +134,40 @@ export function OnboardingFlow({
     if (response.status === 401) setSessionExpired(true);
     if (!response.ok || !data?.checkoutUrl)
       throw new Error(
-        data?.error ??
-          'Checkout couldn’t start. Your app is saved; you can retry or continue to setup.',
+        `${data?.error ?? 'Checkout couldn’t start.'} Your answers are saved. Try again or continue to the dashboard on your current plan.`,
       );
     window.location.assign(data.checkoutUrl);
   }
-
-  function next(nextAnswers = answers) {
-    const validation = onboardingStepError(nextAnswers, step);
+  function next() {
+    if (step === 'plans') return;
+    const validation = onboardingStepError(answers, step);
     if (validation) {
       setError(validation);
       return;
     }
     void run(async () => {
-      const nextStep = ONBOARDING_STEPS[Math.min(index + 1, ONBOARDING_STEPS.length - 1)];
-      const profile = await save({ action: 'save', answers: nextAnswers, step: nextStep });
+      const profile = await save(
+        unsupported || step === 'audience'
+          ? { action: 'complete', answers }
+          : { action: 'save', answers, step: ONBOARDING_QUESTIONS[index + 1] },
+      );
       setAnswers(profile.answers);
       setStep(profile.step);
+      setCompleted(Boolean(profile.completedAt));
+      if (isUnsupportedTechnology(profile.answers.technology) && profile.completedAt)
+        goToDashboard();
     });
   }
-
-  function finish() {
-    if (!unsupported) {
-      const validation = appIdentifierError(slug);
-      if (validation) {
-        setError(validation);
-        return;
-      }
-    }
-    void run(async () => {
-      const profile = await save({
-        action: 'complete',
-        answers,
-        ...(unsupported ? {} : { slug: slug.trim() }),
-      });
-      if (unsupported) {
-        window.location.assign('/dashboard');
-        return;
-      }
-      if (!profile.connectedApp) throw new Error('We couldn’t connect your app. Please try again.');
-      setConnectedApp(profile.connectedApp);
-      try {
-        const key = `otakit:app-tracked:${profile.connectedApp.id}`;
-        if (profile.appCreated && !localStorage.getItem(key)) {
-          localStorage.setItem(key, '1');
-          trackConversion('app_created');
-        }
-      } catch {
-        /* Storage is optional; the database records the app regardless. */
-      }
-      if (needsCheckout) await checkout();
-    });
-  }
-
   function skip() {
+    if (step === 'plans') {
+      goToDashboard();
+      return;
+    }
     void run(async () => {
       await save({ action: 'save', answers, step });
       await save({ action: 'skip' });
-      window.location.assign('/dashboard');
+      goToDashboard();
     });
-  }
-
-  function choosePlan(
-    plan: NonNullable<OnboardingAnswers['selectedPlan']>,
-    interval: 'month' | 'year' = 'month',
-  ) {
-    next({ ...answers, selectedPlan: plan, billingInterval: interval });
   }
 
   return (
@@ -244,8 +181,8 @@ export function OnboardingFlow({
               {organizationName}
             </span>
           </div>
-          {connectedApp ? (
-            <Link href={dashboardHref} className="text-sm underline underline-offset-4">
+          {completed ? (
+            <Link href="/dashboard" className="text-sm underline underline-offset-4">
               Go to dashboard
             </Link>
           ) : (
@@ -255,40 +192,38 @@ export function OnboardingFlow({
           )}
         </div>
       </header>
-
       <main
-        className={`mx-auto px-5 py-8 sm:px-8 sm:py-12 ${step === 'plans' && !connectedApp ? 'max-w-6xl' : 'max-w-3xl'}`}
+        className={`mx-auto px-5 py-8 sm:px-8 sm:py-12 ${step === 'plans' && billingEnabled ? 'max-w-6xl' : 'max-w-3xl'}`}
       >
-        {!connectedApp && (
-          <nav aria-label="Setup progress" className="mb-10">
-            <ol className="grid grid-cols-5 gap-2 sm:gap-4">
-              {ONBOARDING_STEPS.map((item, position) => (
-                <li key={item} aria-current={item === step ? 'step' : undefined}>
-                  <div
-                    className={`mb-2 h-1 rounded-full ${position <= index ? 'bg-foreground' : 'bg-muted'}`}
-                  />
-                  <span
-                    className={`text-xs sm:text-sm ${position === index ? 'font-medium' : 'text-muted-foreground'}`}
-                  >
-                    <span className="hidden sm:inline">{position + 1}. </span>
-                    {STEP_LABELS[position]}
-                  </span>
-                </li>
-              ))}
-            </ol>
-          </nav>
-        )}
-
+        <nav aria-label="Welcome progress" className="mb-10">
+          <ol className="grid grid-cols-4 gap-2 sm:gap-4">
+            {ONBOARDING_STEPS.map((item, position) => (
+              <li key={item} aria-current={item === step ? 'step' : undefined}>
+                <div
+                  className={`mb-2 h-1 rounded-full ${position <= index ? 'bg-foreground' : 'bg-muted'}`}
+                />
+                <span
+                  className={`text-xs sm:text-sm ${position === index ? 'font-medium' : 'text-muted-foreground'}`}
+                >
+                  <span className="hidden sm:inline">{position + 1}. </span>
+                  {STEP_LABELS[position]}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </nav>
         <h1
           ref={heading}
           tabIndex={-1}
           className="text-3xl font-semibold tracking-tight outline-none sm:text-4xl"
         >
-          {connectedApp ? 'Your app is registered. Let’s finish connecting it.' : TITLES[step][0]}
+          {step === 'plans' && !billingEnabled
+            ? 'You’re ready to explore OtaKit.'
+            : TITLES[step][0]}
         </h1>
         <p className="mt-3 max-w-2xl text-base leading-7 text-muted-foreground">
-          {connectedApp
-            ? 'Install and configure the updater so your app can receive its first update.'
+          {step === 'plans' && !billingEnabled
+            ? 'Your answers are saved. Head to the dashboard to get started.'
             : TITLES[step][1]}
         </p>
         {error && (
@@ -306,469 +241,376 @@ export function OnboardingFlow({
             )}
           </p>
         )}
-
-        {connectedApp ? (
-          <div className="mt-8 space-y-6">
-            {(checkoutReturned || hasSubscription) && (
-              <Notice>
-                {hasSubscription
-                  ? `Your workspace is on ${currentPlan === 'pro' ? 'Pro' : currentPlan === 'starter' ? 'Starter' : 'Enterprise'}.`
-                  : 'Checkout completed. Your plan will appear in Billing once payment is confirmed.'}
-              </Notice>
-            )}
-            {needsCheckout && !checkoutReturned && (
-              <Notice>
-                <p>
-                  Your app is saved. Finish checkout for{' '}
-                  {answers.selectedPlan === 'pro' ? 'Pro' : 'Starter'}, or continue setting up on
-                  your current plan.
-                </p>
-                <Button className="mt-3" disabled={busy} onClick={() => void run(() => checkout())}>
-                  {busy && <LoaderCircle className="size-4 animate-spin" />}Continue to checkout
-                </Button>
-              </Notice>
-            )}
-            <div className="rounded-xl border border-border p-5">
-              <p className="text-sm text-muted-foreground">{connectedApp.slug} · OtaKit app ID</p>
-              <CopyCode text={connectedApp.id} />
-              <p className="mt-3 text-sm text-muted-foreground">
-                Use this ID in <code>plugins.OtaKit.appId</code>. Keep your existing native{' '}
-                <code>appId</code> unchanged.
-              </p>
-            </div>
-            <div className="space-y-3">
-              <h2 className="text-lg font-medium">1. Install the updater in your project</h2>
-              <CopyCode text={'npm install @otakit/capacitor-updater\nnpx cap sync'} />
-            </div>
-            <div className="space-y-3">
-              <h2 className="text-lg font-medium">2. Configure it and confirm app startup</h2>
-              <p className="text-sm leading-6 text-muted-foreground">
-                Add the app ID to your Capacitor configuration and call{' '}
-                <code>OtaKit.notifyAppReady()</code> once your app has loaded. The setup guide walks
-                through both changes.
-              </p>
-            </div>
-            <div className="space-y-3">
-              <h2 className="text-lg font-medium">3. Build and test on a device</h2>
-              <p className="text-sm leading-6 text-muted-foreground">
-                Make a native build with the plugin installed. A local test build is enough to try
-                OTA. Existing users need a new App Store or Google Play build containing OtaKit
-                before they can receive its updates.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-3 border-t pt-6">
-              <Button asChild>
-                <a href="https://otakit.com/docs/setup" target="_blank" rel="noreferrer">
-                  Open setup guide
-                  <ArrowRight className="size-4" />
-                </a>
-              </Button>
-              <Button asChild variant="outline">
-                <Link href={dashboardHref}>Go to dashboard</Link>
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <form
-            className="mt-8"
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (step === 'connect' || unsupported) finish();
-              else if (step !== 'plans') next();
-            }}
-          >
-            <fieldset disabled={busy} className="space-y-8 disabled:opacity-70">
-              {step === 'app' && (
-                <>
-                  <Choices
-                    name="technology"
-                    label="What is your app built with?"
-                    value={answers.technology}
-                    onChange={(value) =>
-                      update({
-                        technology: value as OnboardingAnswers['technology'],
-                        framework: undefined,
-                        appStage: undefined,
-                      })
-                    }
-                    options={[
-                      ['capacitor', 'Capacitor / Ionic', 'An iOS or Android app using Capacitor'],
-                      ['web', 'Web app', 'Planning to add iOS or Android with Capacitor'],
-                      ['react_native', 'React Native / Expo'],
-                      ['flutter', 'Flutter'],
-                      ['native', 'Native iOS / Android', 'Swift, Objective-C, Java, or Kotlin'],
-                      ['not_sure', 'Not sure yet'],
-                    ]}
-                  />
-                  {unsupported ? (
-                    <Notice>
-                      <strong>OtaKit currently supports Capacitor apps.</strong>
-                      <p className="mt-2">
-                        It updates the HTML, CSS, and JavaScript inside a Capacitor app. It cannot
-                        update React Native, Flutter, or native app code. You can still explore the
-                        dashboard; we’ll save your interest in this platform.
-                      </p>
-                    </Notice>
-                  ) : (
-                    <>
-                      {(answers.technology === 'capacitor' || answers.technology === 'web') && (
-                        <Choices
-                          name="framework"
-                          label="Which web framework do you use?"
-                          value={answers.framework}
-                          onChange={(value) =>
-                            update({ framework: value as OnboardingAnswers['framework'] })
-                          }
-                          compact
-                          options={[
-                            ['react', 'React'],
-                            ['vue', 'Vue'],
-                            ['angular', 'Angular'],
-                            ['svelte', 'Svelte'],
-                            ['other', 'Another framework'],
-                            ['not_sure', 'Not sure'],
-                          ]}
-                        />
-                      )}
-                      {answers.technology && (
-                        <Choices
-                          name="appStage"
-                          label="Where is your app today?"
-                          value={answers.appStage}
-                          onChange={(value) =>
-                            update({ appStage: value as OnboardingAnswers['appStage'] })
-                          }
-                          options={[
-                            ['live', 'Live with users'],
-                            ['testing', 'Testing a native build'],
-                            ['building', 'Still building'],
-                            ['exploring', 'Just exploring'],
-                          ]}
-                        />
-                      )}
-                      {(answers.technology === 'web' || answers.technology === 'not_sure') && (
-                        <Notice>
-                          You can explore OtaKit now. Before installing the updater, your project
-                          needs an iOS or Android app built with Capacitor.
-                        </Notice>
-                      )}
-                    </>
-                  )}
-                </>
-              )}
-
-              {step === 'updates' && (
-                <>
-                  <Choices
-                    name="otaProvider"
-                    label="Are you already using over-the-air updates?"
-                    value={answers.otaProvider}
-                    onChange={(value) =>
-                      update({
-                        otaProvider: value as OnboardingAnswers['otaProvider'],
-                        otherProvider: undefined,
-                      })
-                    }
-                    options={[
-                      ['none', 'No OTA yet', 'I ship updates through the app stores'],
-                      ['appflow', 'Ionic Appflow'],
-                      ['capgo', 'Capgo'],
-                      ['capawesome', 'Capawesome'],
-                      ['custom', 'Built our own'],
-                      ['other', 'Another provider'],
-                      ['not_sure', 'Not sure'],
-                    ]}
-                  />
-                  {answers.otaProvider === 'other' && (
-                    <div className="space-y-2">
-                      <Label htmlFor="other-provider">
-                        Provider name <span className="text-muted-foreground">(optional)</span>
-                      </Label>
-                      <Input
-                        id="other-provider"
-                        value={answers.otherProvider ?? ''}
-                        maxLength={120}
-                        onChange={(event) => update({ otherProvider: event.target.value })}
-                      />
-                    </div>
-                  )}
-                  <Choices
-                    name="goal"
-                    label="What brought you to OtaKit? (optional)"
-                    value={answers.goal}
-                    onChange={(value) => update({ goal: value as OnboardingAnswers['goal'] })}
-                    options={[
-                      ['start', 'Ship my first OTA update'],
-                      ['migrate', 'Switch providers'],
-                      ['cost', 'Reduce update costs'],
-                      ['explore', 'Compare options'],
-                    ]}
-                  />
-                  {answers.otaProvider && !['none', 'not_sure'].includes(answers.otaProvider) && (
-                    <Notice>
-                      <strong>Switching providers needs one native release.</strong>
-                      <p className="mt-2">
-                        Install OtaKit and test it in a separate build first. Your existing users
-                        will receive OtaKit updates after installing a store build that includes its
-                        plugin.
-                      </p>
-                    </Notice>
-                  )}
-                </>
-              )}
-
-              {step === 'audience' && (
-                <>
-                  <UsageInput
-                    id="active-users"
-                    label="Monthly active users"
-                    hint="People who open your app in a typical month. Enter 0 if you haven’t launched."
-                    value={answers.activeUsers}
-                    max={1_000_000_000}
-                    onChange={(value) => update({ activeUsers: value })}
-                  />
-                  <UsageInput
-                    id="updates-month"
-                    label="OTA updates you expect to ship each month"
-                    hint="A rough estimate helps translate your audience into downloaded updates."
-                    value={answers.updatesPerMonth}
-                    max={1_000}
-                    onChange={(value) => update({ updatesPerMonth: value })}
-                  />
-                  <div className="space-y-2">
-                    <Label htmlFor="source">
-                      How did you hear about OtaKit?{' '}
-                      <span className="text-muted-foreground">(optional)</span>
-                    </Label>
-                    <select
-                      id="source"
-                      className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                      value={answers.source ?? ''}
-                      onChange={(event) =>
-                        update({
-                          source: (event.target.value || undefined) as OnboardingAnswers['source'],
-                          sourceDetail: undefined,
-                        })
-                      }
-                    >
-                      <option value="">Choose a source</option>
-                      <option value="search">Search engine</option>
-                      <option value="ai">AI assistant</option>
-                      <option value="community">Community or social media</option>
-                      <option value="recommendation">Someone recommended it</option>
-                      <option value="launch_site">Product Hunt or a directory</option>
-                      <option value="ad">An ad</option>
-                      <option value="other">Somewhere else</option>
-                    </select>
-                  </div>
-                  {answers.source && (
-                    <div className="space-y-2">
-                      <Label htmlFor="source-detail">
-                        Which one? <span className="text-muted-foreground">(optional)</span>
-                      </Label>
-                      <Input
-                        id="source-detail"
-                        maxLength={120}
-                        placeholder="e.g. Google, Claude, Reddit, Product Hunt"
-                        value={answers.sourceDetail ?? ''}
-                        onChange={(event) => update({ sourceDetail: event.target.value })}
-                      />
-                    </div>
-                  )}
-                </>
-              )}
-
-              {step === 'plans' && (
-                <>
+        <form
+          className="mt-8"
+          onSubmit={(event) => {
+            event.preventDefault();
+            next();
+          }}
+        >
+          <fieldset disabled={busy} className="space-y-8 disabled:opacity-70">
+            {step === 'app' && (
+              <>
+                <Choices
+                  name="technology"
+                  label="What is your app built with?"
+                  value={answers.technology}
+                  onChange={(value) =>
+                    update({
+                      technology: value as OnboardingAnswers['technology'],
+                      framework: undefined,
+                      appStage: undefined,
+                    })
+                  }
+                  options={[
+                    ['capacitor', 'Capacitor / Ionic', 'An iOS or Android app using Capacitor'],
+                    ['web', 'Web app', 'Planning to add iOS or Android with Capacitor'],
+                    ['react_native', 'React Native / Expo'],
+                    ['flutter', 'Flutter'],
+                    ['native', 'Native iOS / Android', 'Swift, Objective-C, Java, or Kotlin'],
+                    ['not_sure', 'Not sure yet'],
+                  ]}
+                />
+                {unsupported ? (
                   <Notice>
-                    {estimatedDownloads === null ? (
-                      'One download means one device downloading one update. You can start Free and change plans later.'
+                    <strong>OtaKit currently supports Capacitor apps.</strong>
+                    <p className="mt-2">
+                      It updates the HTML, CSS, and JavaScript inside a Capacitor app. It cannot
+                      update React Native, Flutter, or native app code. You can still explore the
+                      dashboard; we’ll save your interest in this platform.
+                    </p>
+                  </Notice>
+                ) : (
+                  <>
+                    {(answers.technology === 'capacitor' || answers.technology === 'web') && (
+                      <Choices
+                        name="framework"
+                        label="Which web framework do you use?"
+                        value={answers.framework}
+                        onChange={(value) =>
+                          update({ framework: value as OnboardingAnswers['framework'] })
+                        }
+                        compact
+                        options={[
+                          ['react', 'React'],
+                          ['vue', 'Vue'],
+                          ['angular', 'Angular'],
+                          ['svelte', 'Svelte'],
+                          ['other', 'Another framework'],
+                          ['not_sure', 'Not sure'],
+                        ]}
+                      />
+                    )}
+                    {answers.technology && (
+                      <Choices
+                        name="appStage"
+                        label="Where is your app today?"
+                        value={answers.appStage}
+                        onChange={(value) =>
+                          update({ appStage: value as OnboardingAnswers['appStage'] })
+                        }
+                        options={[
+                          ['live', 'Live with users'],
+                          ['testing', 'Testing a native build'],
+                          ['building', 'Still building'],
+                          ['exploring', 'Just exploring'],
+                        ]}
+                      />
+                    )}
+                    {(answers.technology === 'web' || answers.technology === 'not_sure') && (
+                      <Notice>
+                        You can explore OtaKit now. Before installing the updater, your project
+                        needs an iOS or Android app built with Capacitor.
+                      </Notice>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+
+            {step === 'updates' && (
+              <>
+                <Choices
+                  name="otaProvider"
+                  label="Are you already using over-the-air updates?"
+                  value={answers.otaProvider}
+                  onChange={(value) =>
+                    update({
+                      otaProvider: value as OnboardingAnswers['otaProvider'],
+                      otherProvider: undefined,
+                    })
+                  }
+                  options={[
+                    ['none', 'No OTA yet', 'I ship updates through the app stores'],
+                    ['appflow', 'Ionic Appflow'],
+                    ['capgo', 'Capgo'],
+                    ['capawesome', 'Capawesome'],
+                    ['custom', 'Built our own'],
+                    ['other', 'Another provider'],
+                    ['not_sure', 'Not sure'],
+                  ]}
+                />
+                {answers.otaProvider === 'other' && (
+                  <div className="space-y-2">
+                    <Label htmlFor="other-provider">
+                      Provider name <span className="text-muted-foreground">(optional)</span>
+                    </Label>
+                    <Input
+                      id="other-provider"
+                      value={answers.otherProvider ?? ''}
+                      maxLength={120}
+                      onChange={(event) => update({ otherProvider: event.target.value })}
+                    />
+                  </div>
+                )}
+                <Choices
+                  name="goal"
+                  label="What brought you to OtaKit? (optional)"
+                  value={answers.goal}
+                  onChange={(value) => update({ goal: value as OnboardingAnswers['goal'] })}
+                  options={[
+                    ['start', 'Ship my first OTA update'],
+                    ['migrate', 'Switch providers'],
+                    ['cost', 'Reduce update costs'],
+                    ['explore', 'Compare options'],
+                  ]}
+                />
+                {answers.otaProvider && !['none', 'not_sure'].includes(answers.otaProvider) && (
+                  <Notice>
+                    <strong>Switching providers needs one native release.</strong>
+                    <p className="mt-2">
+                      Install OtaKit and test it in a separate build first. Your existing users will
+                      receive OtaKit updates after installing a store build that includes its
+                      plugin.
+                    </p>
+                  </Notice>
+                )}
+              </>
+            )}
+
+            {step === 'audience' && (
+              <>
+                <UsageInput
+                  id="active-users"
+                  label="Monthly active users"
+                  hint="People who open your app in a typical month. Enter 0 if you haven’t launched."
+                  value={answers.activeUsers}
+                  max={1_000_000_000}
+                  onChange={(value) => update({ activeUsers: value })}
+                />
+                <UsageInput
+                  id="updates-month"
+                  label="OTA updates you expect to ship each month"
+                  hint="A rough estimate helps translate your audience into downloaded updates."
+                  value={answers.updatesPerMonth}
+                  max={1_000}
+                  onChange={(value) => update({ updatesPerMonth: value })}
+                />
+                <div className="space-y-2">
+                  <Label htmlFor="source">
+                    How did you hear about OtaKit?{' '}
+                    <span className="text-muted-foreground">(optional)</span>
+                  </Label>
+                  <select
+                    id="source"
+                    className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                    value={answers.source ?? ''}
+                    onChange={(event) =>
+                      update({
+                        source: (event.target.value || undefined) as OnboardingAnswers['source'],
+                        sourceDetail: undefined,
+                      })
+                    }
+                  >
+                    <option value="">Choose a source</option>
+                    <option value="search">Search engine</option>
+                    <option value="ai">AI assistant</option>
+                    <option value="community">Community or social media</option>
+                    <option value="recommendation">Someone recommended it</option>
+                    <option value="launch_site">Product Hunt or a directory</option>
+                    <option value="ad">An ad</option>
+                    <option value="other">Somewhere else</option>
+                  </select>
+                </div>
+                {answers.source && (
+                  <div className="space-y-2">
+                    <Label htmlFor="source-detail">
+                      Which one? <span className="text-muted-foreground">(optional)</span>
+                    </Label>
+                    <Input
+                      id="source-detail"
+                      maxLength={120}
+                      placeholder="e.g. Google, Claude, Reddit, Product Hunt"
+                      value={answers.sourceDetail ?? ''}
+                      onChange={(event) => update({ sourceDetail: event.target.value })}
+                    />
+                  </div>
+                )}
+              </>
+            )}
+
+            {step === 'plans' && (
+              <>
+                {!billingEnabled ? (
+                  <Notice>
+                    <p>
+                      Your answers are saved. Use the floating setup panel in the dashboard when
+                      you’re ready to connect your app.
+                    </p>
+                    <Button type="button" className="mt-4" onClick={goToDashboard}>
+                      Go to dashboard
+                      <ArrowRight className="size-4" />
+                    </Button>
+                  </Notice>
+                ) : (
+                  <>
+                    <Notice>
+                      {estimatedDownloads === null ? (
+                        'One download means one device downloading one update. You can start Free and change plans later.'
+                      ) : (
+                        <>
+                          Your estimate:{' '}
+                          <strong>
+                            {answers.activeUsers!.toLocaleString('en-US')} active users ×{' '}
+                            {answers.updatesPerMonth} updates ≈{' '}
+                            {estimatedDownloads.toLocaleString('en-US')} downloads/month.
+                          </strong>{' '}
+                          Actual usage depends on active devices and how many updates each device
+                          downloads.
+                        </>
+                      )}
+                    </Notice>
+                    {hasSubscription ? (
+                      <div className="rounded-xl border p-6">
+                        <h2 className="text-lg font-medium">
+                          Your workspace already has{' '}
+                          {currentPlan === 'pro'
+                            ? 'Pro'
+                            : currentPlan === 'starter'
+                              ? 'Starter'
+                              : 'Enterprise'}
+                          .
+                        </h2>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          Your current subscription covers this workspace. You can manage it in
+                          Billing.
+                        </p>
+                        <Button className="mt-5" type="button" onClick={goToDashboard}>
+                          Continue with current plan
+                          <ArrowRight className="size-4" />
+                        </Button>
+                      </div>
                     ) : (
                       <>
-                        Your estimate:{' '}
-                        <strong>
-                          {answers.activeUsers!.toLocaleString('en-US')} active users ×{' '}
-                          {answers.updatesPerMonth} updates ≈{' '}
-                          {estimatedDownloads.toLocaleString('en-US')} downloads/month.
-                        </strong>{' '}
-                        Actual usage depends on active devices and how many updates each device
-                        downloads.
+                        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                          <PlanCard
+                            name="Free"
+                            price="$0"
+                            priceNote="No card required"
+                            subtitle={`${freeDownloads.toLocaleString('en-US')} downloads / month`}
+                            features={[
+                              'Unlimited apps and updates',
+                              'Dashboard + CLI',
+                              'Single-member workspace',
+                              'Hard cap — no overage',
+                            ]}
+                            current={false}
+                            actionLabel="Continue with Free"
+                            actionIcon={Leaf}
+                            disabled={busy}
+                            onAction={goToDashboard}
+                            highlighted={
+                              estimatedDownloads !== null && estimatedDownloads <= freeDownloads
+                            }
+                          />
+                          <PlanCard
+                            name="Starter"
+                            price="$10"
+                            priceNote="Billed monthly"
+                            subtitle="100,000 downloads / month"
+                            features={[
+                              'Unlimited apps and updates',
+                              'Dashboard + CLI',
+                              'Single-member workspace',
+                              'Hard cap — no overage',
+                            ]}
+                            current={false}
+                            actionLabel={
+                              freeDownloads >= 100_000 ? 'Included in Free' : 'Choose Starter'
+                            }
+                            actionIcon={Rocket}
+                            disabled={busy || !billingEnabled || freeDownloads >= 100_000}
+                            onAction={() => void run(() => checkout('starter', 'month'))}
+                            highlighted={
+                              estimatedDownloads !== null &&
+                              estimatedDownloads > freeDownloads &&
+                              estimatedDownloads <= 100_000
+                            }
+                          />
+                          <PlanCard
+                            name="Pro"
+                            price="$25"
+                            priceNote="Billed $300/year, or $50 monthly"
+                            subtitle="1,000,000 downloads / month"
+                            features={[
+                              'Everything in Free',
+                              'Team members and roles',
+                              'Optional overage: $50 / extra 1M',
+                              'Priority support',
+                            ]}
+                            current={false}
+                            actionLabel="Choose Pro"
+                            actionIcon={Star}
+                            disabled={busy || !billingEnabled}
+                            actionItems={[
+                              {
+                                label: 'Yearly',
+                                description: '$300/year · $25/month',
+                                onSelect: () => void run(() => checkout('pro', 'year')),
+                              },
+                              {
+                                label: 'Monthly',
+                                description: '$50/month',
+                                onSelect: () => void run(() => checkout('pro', 'month')),
+                              },
+                            ]}
+                            highlighted={
+                              estimatedDownloads !== null && estimatedDownloads > 100_000
+                            }
+                          />
+                          <PlanCard
+                            name="Enterprise"
+                            price="Custom"
+                            priceNote="Tailored to your volume"
+                            subtitle="Custom download volume"
+                            features={[
+                              'Everything in Pro',
+                              'Custom limits and contract',
+                              'SSO and priority SLAs',
+                              'Dedicated support',
+                            ]}
+                            current={false}
+                            actionLabel="Contact sales"
+                            actionIcon={Building2}
+                            disabled={busy || !billingEnabled}
+                            onAction={() => {
+                              window.location.href = `${SUPPORT_MAILTO}?subject=OtaKit%20Enterprise`;
+                            }}
+                          />
+                        </div>
+                        <p className="text-sm leading-6 text-muted-foreground">
+                          Free and Starter stop serving updates at their included limits. Pro
+                          overage is optional. Choosing a paid plan opens checkout. You can also
+                          continue with Free and upgrade later.
+                        </p>
                       </>
                     )}
-                  </Notice>
-                  {hasSubscription ? (
-                    <div className="rounded-xl border p-6">
-                      <h2 className="text-lg font-medium">
-                        Your workspace already has{' '}
-                        {currentPlan === 'pro'
-                          ? 'Pro'
-                          : currentPlan === 'starter'
-                            ? 'Starter'
-                            : 'Enterprise'}
-                        .
-                      </h2>
-                      <p className="mt-2 text-sm text-muted-foreground">
-                        Your current subscription covers this app. You can manage it in Billing.
-                      </p>
-                      <Button className="mt-5" onClick={() => choosePlan(currentPlan)}>
-                        Continue with current plan
-                        <ArrowRight className="size-4" />
-                      </Button>
-                    </div>
-                  ) : (
-                    <>
-                      {!billingEnabled && (
-                        <Notice>
-                          Billing is not enabled on this instance. Continue with the included plan
-                          to set up your app.
-                        </Notice>
-                      )}
-                      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                        <PlanCard
-                          name="Free"
-                          price="$0"
-                          priceNote="No card required"
-                          subtitle={`${freeDownloads.toLocaleString('en-US')} downloads / month`}
-                          features={[
-                            'Unlimited apps and updates',
-                            'Dashboard + CLI',
-                            'Single-member workspace',
-                            'Hard cap — no overage',
-                          ]}
-                          current={false}
-                          actionLabel="Start Free"
-                          actionIcon={Leaf}
-                          disabled={busy}
-                          onAction={() => choosePlan('free')}
-                          highlighted={
-                            estimatedDownloads !== null && estimatedDownloads <= freeDownloads
-                          }
-                        />
-                        <PlanCard
-                          name="Starter"
-                          price="$10"
-                          priceNote="Billed monthly"
-                          subtitle="100,000 downloads / month"
-                          features={[
-                            'Unlimited apps and updates',
-                            'Dashboard + CLI',
-                            'Single-member workspace',
-                            'Hard cap — no overage',
-                          ]}
-                          current={false}
-                          actionLabel="Choose Starter"
-                          actionIcon={Rocket}
-                          disabled={busy || !billingEnabled || freeDownloads >= 100_000}
-                          onAction={() => choosePlan('starter')}
-                          highlighted={
-                            estimatedDownloads !== null &&
-                            estimatedDownloads > freeDownloads &&
-                            estimatedDownloads <= 100_000
-                          }
-                        />
-                        <PlanCard
-                          name="Pro"
-                          price="$25"
-                          priceNote="Billed $300/year, or $50 monthly"
-                          subtitle="1,000,000 downloads / month"
-                          features={[
-                            'Everything in Free',
-                            'Team members and roles',
-                            'Optional overage: $50 / extra 1M',
-                            'Priority support',
-                          ]}
-                          current={false}
-                          actionLabel="Choose Pro"
-                          actionIcon={Star}
-                          disabled={busy || !billingEnabled}
-                          actionItems={[
-                            {
-                              label: 'Yearly',
-                              description: '$300/year · $25/month',
-                              onSelect: () => choosePlan('pro', 'year'),
-                            },
-                            {
-                              label: 'Monthly',
-                              description: '$50/month',
-                              onSelect: () => choosePlan('pro', 'month'),
-                            },
-                          ]}
-                          highlighted={estimatedDownloads !== null && estimatedDownloads > 100_000}
-                        />
-                        <PlanCard
-                          name="Enterprise"
-                          price="Custom"
-                          priceNote="Tailored to your volume"
-                          subtitle="Custom download volume"
-                          features={[
-                            'Everything in Pro',
-                            'Custom limits and contract',
-                            'SSO and priority SLAs',
-                            'Dedicated support',
-                          ]}
-                          current={false}
-                          actionLabel="Contact sales"
-                          actionIcon={Building2}
-                          disabled={busy || !billingEnabled}
-                          onAction={() => {
-                            window.location.href = `${SUPPORT_MAILTO}?subject=OtaKit%20Enterprise`;
-                          }}
-                        />
-                      </div>
-                      <p className="text-sm leading-6 text-muted-foreground">
-                        Free and Starter stop serving updates at their included limits. Pro overage
-                        is optional. Paid plans open checkout after you register your app; selecting
-                        a plan here does not charge you.
-                      </p>
-                    </>
-                  )}
-                </>
-              )}
-
-              {step === 'connect' && (
-                <>
-                  <div className="space-y-3">
-                    <Label htmlFor="app-identifier">App identifier</Label>
-                    <Input
-                      id="app-identifier"
-                      autoComplete="off"
-                      autoCapitalize="none"
-                      spellCheck={false}
-                      maxLength={120}
-                      placeholder="my-app"
-                      value={slug}
-                      onChange={(event) => {
-                        setSlug(event.target.value);
-                        setError(null);
-                      }}
-                      aria-describedby="identifier-help"
-                      aria-invalid={Boolean(error)}
-                      className="h-12 text-base"
-                    />
-                    <p id="identifier-help" className="text-sm leading-6 text-muted-foreground">
-                      Choose any unique label within this workspace, such as <code>my-app</code> or{' '}
-                      <code>acme-mobile</code>. It does not need to match your App Store, Android,
-                      or Capacitor app ID. Use 3–120 letters, numbers, dots, underscores, or
-                      hyphens.
-                    </p>
-                  </div>
-                  <Notice>
-                    <strong>
-                      {hasSubscription
-                        ? `Covered by your current ${currentPlan} plan.`
-                        : answers.selectedPlan === 'free'
-                          ? 'Starting on Free. No credit card required.'
-                          : `Selected: ${answers.selectedPlan === 'pro' ? `Pro — ${answers.billingInterval === 'year' ? '$300/year' : '$50/month'}` : 'Starter — $10/month'}.`}
-                    </strong>
-                    <p className="mt-2">
-                      This registers your app in OtaKit. Next, we’ll show you the plugin
-                      installation and your OtaKit app ID. Registering here does not change your
-                      existing app or publish an update.
-                    </p>
-                  </Notice>
-                </>
-              )}
-            </fieldset>
+                  </>
+                )}
+              </>
+            )}
+          </fieldset>
+          {step !== 'plans' && (
             <div className="mt-10 flex flex-wrap items-center justify-between gap-4 border-t border-border pt-6">
               {index > 0 ? (
                 <Button
@@ -788,26 +630,24 @@ export function OnboardingFlow({
                   Progress saves when you continue.
                 </span>
               )}
-              {step !== 'plans' && (
-                <Button
-                  type="submit"
-                  disabled={busy}
-                  className="ml-auto h-auto min-h-9 max-w-full shrink-0 whitespace-normal py-2"
-                >
-                  {busy ? <LoaderCircle className="size-4 animate-spin" /> : null}
-                  {unsupported
-                    ? 'Save and explore dashboard'
-                    : step === 'connect'
-                      ? needsCheckout
-                        ? 'Connect and continue to checkout'
-                        : 'Connect your app'
-                      : 'Continue'}
-                  {!busy && <ArrowRight className="size-4" />}
-                </Button>
-              )}
+              <Button
+                type="submit"
+                disabled={busy}
+                className="ml-auto h-auto min-h-9 max-w-full shrink-0 whitespace-normal py-2"
+              >
+                {busy && <LoaderCircle className="size-4 animate-spin" />}
+                {unsupported
+                  ? 'Save and explore dashboard'
+                  : step === 'audience'
+                    ? billingEnabled
+                      ? 'See plans'
+                      : 'Finish questions'
+                    : 'Continue'}
+                {!busy && <ArrowRight className="size-4" />}
+              </Button>
             </div>
-          </form>
-        )}
+          )}
+        </form>
         <p className="mt-10 text-sm text-muted-foreground">
           Need a hand?{' '}
           <a href={SUPPORT_MAILTO} className="underline underline-offset-4 hover:text-foreground">
@@ -920,47 +760,6 @@ function UsageInput({
           Not sure yet
         </label>
       </div>
-    </div>
-  );
-}
-
-function CopyCode({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  const [copyError, setCopyError] = useState(false);
-  useEffect(() => {
-    if (!copied) return;
-    const timer = setTimeout(() => setCopied(false), 2000);
-    return () => clearTimeout(timer);
-  }, [copied]);
-  return (
-    <div className="mt-3">
-      <div className="flex items-start gap-3 rounded-lg bg-muted p-4">
-        <pre
-          tabIndex={0}
-          className="min-w-0 flex-1 overflow-x-auto rounded-sm text-sm leading-6 focus-visible:outline-2 focus-visible:outline-ring"
-        >
-          <code>{text}</code>
-        </pre>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Copy to clipboard"
-          onClick={async () => {
-            try {
-              await navigator.clipboard.writeText(text);
-              setCopied(true);
-              setCopyError(false);
-            } catch {
-              setCopyError(true);
-            }
-          }}
-        >
-          {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
-        </Button>
-      </div>
-      <span className="text-xs text-muted-foreground" role="status">
-        {copyError ? 'Select and copy the text above.' : copied ? 'Copied' : ''}
-      </span>
     </div>
   );
 }

--- a/packages/console/app/onboarding/OnboardingFlow.tsx
+++ b/packages/console/app/onboarding/OnboardingFlow.tsx
@@ -15,6 +15,7 @@ import {
   ONBOARDING_STEPS,
   estimateMonthlyDownloads,
   isUnsupportedTechnology,
+  onboardingAnswersSchema,
   onboardingStepError,
   type OnboardingAnswers,
   type OnboardingProfile,
@@ -164,8 +165,10 @@ export function OnboardingFlow({
       return;
     }
     void run(async () => {
-      await save({ action: 'save', answers, step });
-      await save({ action: 'skip' });
+      // Skipping must work even when the current draft contains an invalid number.
+      // Keep valid draft answers in the same request; otherwise retain the last save.
+      const draft = onboardingAnswersSchema.safeParse(answers);
+      await save({ action: 'skip', ...(draft.success ? { answers: draft.data } : {}) });
       goToDashboard();
     });
   }
@@ -394,6 +397,7 @@ export function OnboardingFlow({
                   id="active-users"
                   label="Monthly active users"
                   hint="People who open your app in a typical month. Enter 0 if you haven’t launched."
+                  placeholder="e.g. 1000"
                   value={answers.activeUsers}
                   max={1_000_000_000}
                   onChange={(value) => update({ activeUsers: value })}
@@ -402,6 +406,7 @@ export function OnboardingFlow({
                   id="updates-month"
                   label="OTA updates you expect to ship each month"
                   hint="A rough estimate helps translate your audience into downloaded updates."
+                  placeholder="e.g. 4"
                   value={answers.updatesPerMonth}
                   max={1_000}
                   onChange={(value) => update({ updatesPerMonth: value })}
@@ -717,6 +722,7 @@ function UsageInput({
   id,
   label,
   hint,
+  placeholder,
   value,
   max,
   onChange,
@@ -724,6 +730,7 @@ function UsageInput({
   id: string;
   label: string;
   hint: string;
+  placeholder: string;
   value: number | null | undefined;
   max: number;
   onChange: (value: number | null | undefined) => void;
@@ -743,7 +750,7 @@ function UsageInput({
           min={0}
           max={max}
           step={1}
-          placeholder="e.g. 1000"
+          placeholder={placeholder}
           value={value ?? ''}
           aria-describedby={`${id}-hint`}
           onChange={(event) =>

--- a/packages/console/app/onboarding/OnboardingFlow.tsx
+++ b/packages/console/app/onboarding/OnboardingFlow.tsx
@@ -1,0 +1,966 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  ArrowLeft,
+  ArrowRight,
+  Building2,
+  Check,
+  Copy,
+  Leaf,
+  LoaderCircle,
+  Rocket,
+  Star,
+} from 'lucide-react';
+
+import { PlanCard, type PlanKey } from '@/app/components/PricingDialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { SUPPORT_MAILTO } from '@/lib/support';
+import { trackConversion } from '@/lib/gtag';
+import {
+  ONBOARDING_STEPS,
+  appIdentifierError,
+  estimateMonthlyDownloads,
+  isUnsupportedTechnology,
+  onboardingStepError,
+  type OnboardingAnswers,
+  type OnboardingProfile,
+  type OnboardingRequest,
+  type OnboardingStep,
+} from '@/lib/onboarding-profile';
+
+const STEP_LABELS = ['Your app', 'Updates', 'Audience', 'Plan', 'Connect'];
+const TITLES: Record<OnboardingStep, [string, string]> = {
+  app: [
+    'Let’s start with your app.',
+    'A few details will help us show you the right setup and pricing.',
+  ],
+  updates: [
+    'How do you ship updates today?',
+    'We’ll use this to guide your first release or migration.',
+  ],
+  audience: [
+    'How many people use your app?',
+    'An estimate is enough. This helps you compare plans by expected usage.',
+  ],
+  plans: [
+    'Choose your starting plan.',
+    'Every plan includes unlimited apps and updates. Usage is measured by downloaded updates.',
+  ],
+  connect: [
+    'Connect your app to OtaKit.',
+    'First, give it an identifier. Then install the plugin in your project.',
+  ],
+};
+
+export function OnboardingFlow({
+  organizationId,
+  organizationName,
+  initialProfile,
+  billingEnabled,
+  currentPlan,
+  hasSubscription,
+  freeDownloads,
+}: {
+  organizationId: string;
+  organizationName: string;
+  initialProfile: OnboardingProfile | null;
+  billingEnabled: boolean;
+  currentPlan: PlanKey;
+  hasSubscription: boolean;
+  freeDownloads: number;
+}) {
+  const [answers, setAnswers] = useState<OnboardingAnswers>(initialProfile?.answers ?? {});
+  const [step, setStep] = useState<OnboardingStep>(initialProfile?.step ?? 'app');
+  const [connectedApp, setConnectedApp] = useState(initialProfile?.connectedApp ?? null);
+  const [slug, setSlug] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionExpired, setSessionExpired] = useState(false);
+  const [checkoutReturned, setCheckoutReturned] = useState(false);
+  const busyRef = useRef(false);
+  const heading = useRef<HTMLHeadingElement>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
+  const index = ONBOARDING_STEPS.indexOf(step);
+  const unsupported = isUnsupportedTechnology(answers.technology);
+  const estimatedDownloads = estimateMonthlyDownloads(answers);
+  const needsCheckout =
+    billingEnabled &&
+    !hasSubscription &&
+    (answers.selectedPlan === 'starter' || answers.selectedPlan === 'pro');
+  const dashboardHref = connectedApp
+    ? `/dashboard?app=${encodeURIComponent(connectedApp.id)}`
+    : '/dashboard';
+
+  useEffect(() => {
+    heading.current?.focus();
+  }, [step, connectedApp]);
+  useEffect(() => {
+    if (error) errorRef.current?.focus();
+  }, [error]);
+  useEffect(() => {
+    setCheckoutReturned(new URLSearchParams(window.location.search).get('checkout') === 'success');
+  }, []);
+
+  function update(patch: Partial<OnboardingAnswers>) {
+    setAnswers((current) => ({ ...current, ...patch }));
+    setError(null);
+  }
+
+  async function save(input: OnboardingRequest) {
+    const response = await fetch('/api/v1/organization/onboarding/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-otakit-organization-id': organizationId },
+      body: JSON.stringify(input),
+    });
+    if (response.status === 401) {
+      setSessionExpired(true);
+      throw new Error(
+        'Your session expired. Sign in again to continue; your saved progress will be here.',
+      );
+    }
+    const data = (await response.json().catch(() => null)) as {
+      profile?: OnboardingProfile & { appCreated?: boolean };
+      error?: string;
+    } | null;
+    if (!response.ok || !data?.profile)
+      throw new Error(data?.error ?? 'We couldn’t save your progress. Please try again.');
+    return data.profile;
+  }
+
+  async function run(action: () => Promise<void>) {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(null);
+    setSessionExpired(false);
+    try {
+      await action();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Something went wrong. Please try again.');
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }
+
+  async function checkout(plan: OnboardingAnswers['selectedPlan'] = answers.selectedPlan) {
+    const response = await fetch('/api/v1/organization/billing/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-otakit-organization-id': organizationId },
+      body: JSON.stringify({
+        planKey: plan,
+        interval: answers.billingInterval ?? 'month',
+        returnTo: 'onboarding',
+      }),
+    });
+    const data = (await response.json().catch(() => null)) as {
+      checkoutUrl?: string;
+      error?: string;
+    } | null;
+    if (response.status === 401) setSessionExpired(true);
+    if (!response.ok || !data?.checkoutUrl)
+      throw new Error(
+        data?.error ??
+          'Checkout couldn’t start. Your app is saved; you can retry or continue to setup.',
+      );
+    window.location.assign(data.checkoutUrl);
+  }
+
+  function next(nextAnswers = answers) {
+    const validation = onboardingStepError(nextAnswers, step);
+    if (validation) {
+      setError(validation);
+      return;
+    }
+    void run(async () => {
+      const nextStep = ONBOARDING_STEPS[Math.min(index + 1, ONBOARDING_STEPS.length - 1)];
+      const profile = await save({ action: 'save', answers: nextAnswers, step: nextStep });
+      setAnswers(profile.answers);
+      setStep(profile.step);
+    });
+  }
+
+  function finish() {
+    if (!unsupported) {
+      const validation = appIdentifierError(slug);
+      if (validation) {
+        setError(validation);
+        return;
+      }
+    }
+    void run(async () => {
+      const profile = await save({
+        action: 'complete',
+        answers,
+        ...(unsupported ? {} : { slug: slug.trim() }),
+      });
+      if (unsupported) {
+        window.location.assign('/dashboard');
+        return;
+      }
+      if (!profile.connectedApp) throw new Error('We couldn’t connect your app. Please try again.');
+      setConnectedApp(profile.connectedApp);
+      try {
+        const key = `otakit:app-tracked:${profile.connectedApp.id}`;
+        if (profile.appCreated && !localStorage.getItem(key)) {
+          localStorage.setItem(key, '1');
+          trackConversion('app_created');
+        }
+      } catch {
+        /* Storage is optional; the database records the app regardless. */
+      }
+      if (needsCheckout) await checkout();
+    });
+  }
+
+  function skip() {
+    void run(async () => {
+      await save({ action: 'save', answers, step });
+      await save({ action: 'skip' });
+      window.location.assign('/dashboard');
+    });
+  }
+
+  function choosePlan(
+    plan: NonNullable<OnboardingAnswers['selectedPlan']>,
+    interval: 'month' | 'year' = 'month',
+  ) {
+    next({ ...answers, selectedPlan: plan, billingInterval: interval });
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="border-b border-border">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-5 py-5 sm:px-8">
+          <div className="flex min-w-0 items-center gap-3">
+            <Image src="/logo.svg" width={28} height={28} alt="" />
+            <span className="text-lg font-semibold tracking-tight">OtaKit</span>
+            <span className="hidden truncate border-l pl-3 text-sm text-muted-foreground sm:block">
+              {organizationName}
+            </span>
+          </div>
+          {connectedApp ? (
+            <Link href={dashboardHref} className="text-sm underline underline-offset-4">
+              Go to dashboard
+            </Link>
+          ) : (
+            <Button variant="ghost" size="sm" disabled={busy} onClick={skip}>
+              Skip for now
+            </Button>
+          )}
+        </div>
+      </header>
+
+      <main
+        className={`mx-auto px-5 py-8 sm:px-8 sm:py-12 ${step === 'plans' && !connectedApp ? 'max-w-6xl' : 'max-w-3xl'}`}
+      >
+        {!connectedApp && (
+          <nav aria-label="Setup progress" className="mb-10">
+            <ol className="grid grid-cols-5 gap-2 sm:gap-4">
+              {ONBOARDING_STEPS.map((item, position) => (
+                <li key={item} aria-current={item === step ? 'step' : undefined}>
+                  <div
+                    className={`mb-2 h-1 rounded-full ${position <= index ? 'bg-foreground' : 'bg-muted'}`}
+                  />
+                  <span
+                    className={`text-xs sm:text-sm ${position === index ? 'font-medium' : 'text-muted-foreground'}`}
+                  >
+                    <span className="hidden sm:inline">{position + 1}. </span>
+                    {STEP_LABELS[position]}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </nav>
+        )}
+
+        <h1
+          ref={heading}
+          tabIndex={-1}
+          className="text-3xl font-semibold tracking-tight outline-none sm:text-4xl"
+        >
+          {connectedApp ? 'Your app is registered. Let’s finish connecting it.' : TITLES[step][0]}
+        </h1>
+        <p className="mt-3 max-w-2xl text-base leading-7 text-muted-foreground">
+          {connectedApp
+            ? 'Install and configure the updater so your app can receive its first update.'
+            : TITLES[step][1]}
+        </p>
+        {error && (
+          <p
+            ref={errorRef}
+            tabIndex={-1}
+            role="alert"
+            className="mt-6 rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive outline-none"
+          >
+            {error}
+            {sessionExpired && (
+              <Link href="/login" className="ml-2 font-medium underline underline-offset-4">
+                Sign in again
+              </Link>
+            )}
+          </p>
+        )}
+
+        {connectedApp ? (
+          <div className="mt-8 space-y-6">
+            {(checkoutReturned || hasSubscription) && (
+              <Notice>
+                {hasSubscription
+                  ? `Your workspace is on ${currentPlan === 'pro' ? 'Pro' : currentPlan === 'starter' ? 'Starter' : 'Enterprise'}.`
+                  : 'Checkout completed. Your plan will appear in Billing once payment is confirmed.'}
+              </Notice>
+            )}
+            {needsCheckout && !checkoutReturned && (
+              <Notice>
+                <p>
+                  Your app is saved. Finish checkout for{' '}
+                  {answers.selectedPlan === 'pro' ? 'Pro' : 'Starter'}, or continue setting up on
+                  your current plan.
+                </p>
+                <Button className="mt-3" disabled={busy} onClick={() => void run(() => checkout())}>
+                  {busy && <LoaderCircle className="size-4 animate-spin" />}Continue to checkout
+                </Button>
+              </Notice>
+            )}
+            <div className="rounded-xl border border-border p-5">
+              <p className="text-sm text-muted-foreground">{connectedApp.slug} · OtaKit app ID</p>
+              <CopyCode text={connectedApp.id} />
+              <p className="mt-3 text-sm text-muted-foreground">
+                Use this ID in <code>plugins.OtaKit.appId</code>. Keep your existing native{' '}
+                <code>appId</code> unchanged.
+              </p>
+            </div>
+            <div className="space-y-3">
+              <h2 className="text-lg font-medium">1. Install the updater in your project</h2>
+              <CopyCode text={'npm install @otakit/capacitor-updater\nnpx cap sync'} />
+            </div>
+            <div className="space-y-3">
+              <h2 className="text-lg font-medium">2. Configure it and confirm app startup</h2>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Add the app ID to your Capacitor configuration and call{' '}
+                <code>OtaKit.notifyAppReady()</code> once your app has loaded. The setup guide walks
+                through both changes.
+              </p>
+            </div>
+            <div className="space-y-3">
+              <h2 className="text-lg font-medium">3. Build and test on a device</h2>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Make a native build with the plugin installed. A local test build is enough to try
+                OTA. Existing users need a new App Store or Google Play build containing OtaKit
+                before they can receive its updates.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3 border-t pt-6">
+              <Button asChild>
+                <a href="https://otakit.com/docs/setup" target="_blank" rel="noreferrer">
+                  Open setup guide
+                  <ArrowRight className="size-4" />
+                </a>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href={dashboardHref}>Go to dashboard</Link>
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <form
+            className="mt-8"
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (step === 'connect' || unsupported) finish();
+              else if (step !== 'plans') next();
+            }}
+          >
+            <fieldset disabled={busy} className="space-y-8 disabled:opacity-70">
+              {step === 'app' && (
+                <>
+                  <Choices
+                    name="technology"
+                    label="What is your app built with?"
+                    value={answers.technology}
+                    onChange={(value) =>
+                      update({
+                        technology: value as OnboardingAnswers['technology'],
+                        framework: undefined,
+                        appStage: undefined,
+                      })
+                    }
+                    options={[
+                      ['capacitor', 'Capacitor / Ionic', 'An iOS or Android app using Capacitor'],
+                      ['web', 'Web app', 'Planning to add iOS or Android with Capacitor'],
+                      ['react_native', 'React Native / Expo'],
+                      ['flutter', 'Flutter'],
+                      ['native', 'Native iOS / Android', 'Swift, Objective-C, Java, or Kotlin'],
+                      ['not_sure', 'Not sure yet'],
+                    ]}
+                  />
+                  {unsupported ? (
+                    <Notice>
+                      <strong>OtaKit currently supports Capacitor apps.</strong>
+                      <p className="mt-2">
+                        It updates the HTML, CSS, and JavaScript inside a Capacitor app. It cannot
+                        update React Native, Flutter, or native app code. You can still explore the
+                        dashboard; we’ll save your interest in this platform.
+                      </p>
+                    </Notice>
+                  ) : (
+                    <>
+                      {(answers.technology === 'capacitor' || answers.technology === 'web') && (
+                        <Choices
+                          name="framework"
+                          label="Which web framework do you use?"
+                          value={answers.framework}
+                          onChange={(value) =>
+                            update({ framework: value as OnboardingAnswers['framework'] })
+                          }
+                          compact
+                          options={[
+                            ['react', 'React'],
+                            ['vue', 'Vue'],
+                            ['angular', 'Angular'],
+                            ['svelte', 'Svelte'],
+                            ['other', 'Another framework'],
+                            ['not_sure', 'Not sure'],
+                          ]}
+                        />
+                      )}
+                      {answers.technology && (
+                        <Choices
+                          name="appStage"
+                          label="Where is your app today?"
+                          value={answers.appStage}
+                          onChange={(value) =>
+                            update({ appStage: value as OnboardingAnswers['appStage'] })
+                          }
+                          options={[
+                            ['live', 'Live with users'],
+                            ['testing', 'Testing a native build'],
+                            ['building', 'Still building'],
+                            ['exploring', 'Just exploring'],
+                          ]}
+                        />
+                      )}
+                      {(answers.technology === 'web' || answers.technology === 'not_sure') && (
+                        <Notice>
+                          You can explore OtaKit now. Before installing the updater, your project
+                          needs an iOS or Android app built with Capacitor.
+                        </Notice>
+                      )}
+                    </>
+                  )}
+                </>
+              )}
+
+              {step === 'updates' && (
+                <>
+                  <Choices
+                    name="otaProvider"
+                    label="Are you already using over-the-air updates?"
+                    value={answers.otaProvider}
+                    onChange={(value) =>
+                      update({
+                        otaProvider: value as OnboardingAnswers['otaProvider'],
+                        otherProvider: undefined,
+                      })
+                    }
+                    options={[
+                      ['none', 'No OTA yet', 'I ship updates through the app stores'],
+                      ['appflow', 'Ionic Appflow'],
+                      ['capgo', 'Capgo'],
+                      ['capawesome', 'Capawesome'],
+                      ['custom', 'Built our own'],
+                      ['other', 'Another provider'],
+                      ['not_sure', 'Not sure'],
+                    ]}
+                  />
+                  {answers.otaProvider === 'other' && (
+                    <div className="space-y-2">
+                      <Label htmlFor="other-provider">
+                        Provider name <span className="text-muted-foreground">(optional)</span>
+                      </Label>
+                      <Input
+                        id="other-provider"
+                        value={answers.otherProvider ?? ''}
+                        maxLength={120}
+                        onChange={(event) => update({ otherProvider: event.target.value })}
+                      />
+                    </div>
+                  )}
+                  <Choices
+                    name="goal"
+                    label="What brought you to OtaKit? (optional)"
+                    value={answers.goal}
+                    onChange={(value) => update({ goal: value as OnboardingAnswers['goal'] })}
+                    options={[
+                      ['start', 'Ship my first OTA update'],
+                      ['migrate', 'Switch providers'],
+                      ['cost', 'Reduce update costs'],
+                      ['explore', 'Compare options'],
+                    ]}
+                  />
+                  {answers.otaProvider && !['none', 'not_sure'].includes(answers.otaProvider) && (
+                    <Notice>
+                      <strong>Switching providers needs one native release.</strong>
+                      <p className="mt-2">
+                        Install OtaKit and test it in a separate build first. Your existing users
+                        will receive OtaKit updates after installing a store build that includes its
+                        plugin.
+                      </p>
+                    </Notice>
+                  )}
+                </>
+              )}
+
+              {step === 'audience' && (
+                <>
+                  <UsageInput
+                    id="active-users"
+                    label="Monthly active users"
+                    hint="People who open your app in a typical month. Enter 0 if you haven’t launched."
+                    value={answers.activeUsers}
+                    max={1_000_000_000}
+                    onChange={(value) => update({ activeUsers: value })}
+                  />
+                  <UsageInput
+                    id="updates-month"
+                    label="OTA updates you expect to ship each month"
+                    hint="A rough estimate helps translate your audience into downloaded updates."
+                    value={answers.updatesPerMonth}
+                    max={1_000}
+                    onChange={(value) => update({ updatesPerMonth: value })}
+                  />
+                  <div className="space-y-2">
+                    <Label htmlFor="source">
+                      How did you hear about OtaKit?{' '}
+                      <span className="text-muted-foreground">(optional)</span>
+                    </Label>
+                    <select
+                      id="source"
+                      className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      value={answers.source ?? ''}
+                      onChange={(event) =>
+                        update({
+                          source: (event.target.value || undefined) as OnboardingAnswers['source'],
+                          sourceDetail: undefined,
+                        })
+                      }
+                    >
+                      <option value="">Choose a source</option>
+                      <option value="search">Search engine</option>
+                      <option value="ai">AI assistant</option>
+                      <option value="community">Community or social media</option>
+                      <option value="recommendation">Someone recommended it</option>
+                      <option value="launch_site">Product Hunt or a directory</option>
+                      <option value="ad">An ad</option>
+                      <option value="other">Somewhere else</option>
+                    </select>
+                  </div>
+                  {answers.source && (
+                    <div className="space-y-2">
+                      <Label htmlFor="source-detail">
+                        Which one? <span className="text-muted-foreground">(optional)</span>
+                      </Label>
+                      <Input
+                        id="source-detail"
+                        maxLength={120}
+                        placeholder="e.g. Google, Claude, Reddit, Product Hunt"
+                        value={answers.sourceDetail ?? ''}
+                        onChange={(event) => update({ sourceDetail: event.target.value })}
+                      />
+                    </div>
+                  )}
+                </>
+              )}
+
+              {step === 'plans' && (
+                <>
+                  <Notice>
+                    {estimatedDownloads === null ? (
+                      'One download means one device downloading one update. You can start Free and change plans later.'
+                    ) : (
+                      <>
+                        Your estimate:{' '}
+                        <strong>
+                          {answers.activeUsers!.toLocaleString('en-US')} active users ×{' '}
+                          {answers.updatesPerMonth} updates ≈{' '}
+                          {estimatedDownloads.toLocaleString('en-US')} downloads/month.
+                        </strong>{' '}
+                        Actual usage depends on active devices and how many updates each device
+                        downloads.
+                      </>
+                    )}
+                  </Notice>
+                  {hasSubscription ? (
+                    <div className="rounded-xl border p-6">
+                      <h2 className="text-lg font-medium">
+                        Your workspace already has{' '}
+                        {currentPlan === 'pro'
+                          ? 'Pro'
+                          : currentPlan === 'starter'
+                            ? 'Starter'
+                            : 'Enterprise'}
+                        .
+                      </h2>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        Your current subscription covers this app. You can manage it in Billing.
+                      </p>
+                      <Button className="mt-5" onClick={() => choosePlan(currentPlan)}>
+                        Continue with current plan
+                        <ArrowRight className="size-4" />
+                      </Button>
+                    </div>
+                  ) : (
+                    <>
+                      {!billingEnabled && (
+                        <Notice>
+                          Billing is not enabled on this instance. Continue with the included plan
+                          to set up your app.
+                        </Notice>
+                      )}
+                      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                        <PlanCard
+                          name="Free"
+                          price="$0"
+                          priceNote="No card required"
+                          subtitle={`${freeDownloads.toLocaleString('en-US')} downloads / month`}
+                          features={[
+                            'Unlimited apps and updates',
+                            'Dashboard + CLI',
+                            'Single-member workspace',
+                            'Hard cap — no overage',
+                          ]}
+                          current={false}
+                          actionLabel="Start Free"
+                          actionIcon={Leaf}
+                          disabled={busy}
+                          onAction={() => choosePlan('free')}
+                          highlighted={
+                            estimatedDownloads !== null && estimatedDownloads <= freeDownloads
+                          }
+                        />
+                        <PlanCard
+                          name="Starter"
+                          price="$10"
+                          priceNote="Billed monthly"
+                          subtitle="100,000 downloads / month"
+                          features={[
+                            'Unlimited apps and updates',
+                            'Dashboard + CLI',
+                            'Single-member workspace',
+                            'Hard cap — no overage',
+                          ]}
+                          current={false}
+                          actionLabel="Choose Starter"
+                          actionIcon={Rocket}
+                          disabled={busy || !billingEnabled || freeDownloads >= 100_000}
+                          onAction={() => choosePlan('starter')}
+                          highlighted={
+                            estimatedDownloads !== null &&
+                            estimatedDownloads > freeDownloads &&
+                            estimatedDownloads <= 100_000
+                          }
+                        />
+                        <PlanCard
+                          name="Pro"
+                          price="$25"
+                          priceNote="Billed $300/year, or $50 monthly"
+                          subtitle="1,000,000 downloads / month"
+                          features={[
+                            'Everything in Free',
+                            'Team members and roles',
+                            'Optional overage: $50 / extra 1M',
+                            'Priority support',
+                          ]}
+                          current={false}
+                          actionLabel="Choose Pro"
+                          actionIcon={Star}
+                          disabled={busy || !billingEnabled}
+                          actionItems={[
+                            {
+                              label: 'Yearly',
+                              description: '$300/year · $25/month',
+                              onSelect: () => choosePlan('pro', 'year'),
+                            },
+                            {
+                              label: 'Monthly',
+                              description: '$50/month',
+                              onSelect: () => choosePlan('pro', 'month'),
+                            },
+                          ]}
+                          highlighted={estimatedDownloads !== null && estimatedDownloads > 100_000}
+                        />
+                        <PlanCard
+                          name="Enterprise"
+                          price="Custom"
+                          priceNote="Tailored to your volume"
+                          subtitle="Custom download volume"
+                          features={[
+                            'Everything in Pro',
+                            'Custom limits and contract',
+                            'SSO and priority SLAs',
+                            'Dedicated support',
+                          ]}
+                          current={false}
+                          actionLabel="Contact sales"
+                          actionIcon={Building2}
+                          disabled={busy || !billingEnabled}
+                          onAction={() => {
+                            window.location.href = `${SUPPORT_MAILTO}?subject=OtaKit%20Enterprise`;
+                          }}
+                        />
+                      </div>
+                      <p className="text-sm leading-6 text-muted-foreground">
+                        Free and Starter stop serving updates at their included limits. Pro overage
+                        is optional. Paid plans open checkout after you register your app; selecting
+                        a plan here does not charge you.
+                      </p>
+                    </>
+                  )}
+                </>
+              )}
+
+              {step === 'connect' && (
+                <>
+                  <div className="space-y-3">
+                    <Label htmlFor="app-identifier">App identifier</Label>
+                    <Input
+                      id="app-identifier"
+                      autoComplete="off"
+                      autoCapitalize="none"
+                      spellCheck={false}
+                      maxLength={120}
+                      placeholder="my-app"
+                      value={slug}
+                      onChange={(event) => {
+                        setSlug(event.target.value);
+                        setError(null);
+                      }}
+                      aria-describedby="identifier-help"
+                      aria-invalid={Boolean(error)}
+                      className="h-12 text-base"
+                    />
+                    <p id="identifier-help" className="text-sm leading-6 text-muted-foreground">
+                      Choose any unique label within this workspace, such as <code>my-app</code> or{' '}
+                      <code>acme-mobile</code>. It does not need to match your App Store, Android,
+                      or Capacitor app ID. Use 3–120 letters, numbers, dots, underscores, or
+                      hyphens.
+                    </p>
+                  </div>
+                  <Notice>
+                    <strong>
+                      {hasSubscription
+                        ? `Covered by your current ${currentPlan} plan.`
+                        : answers.selectedPlan === 'free'
+                          ? 'Starting on Free. No credit card required.'
+                          : `Selected: ${answers.selectedPlan === 'pro' ? `Pro — ${answers.billingInterval === 'year' ? '$300/year' : '$50/month'}` : 'Starter — $10/month'}.`}
+                    </strong>
+                    <p className="mt-2">
+                      This registers your app in OtaKit. Next, we’ll show you the plugin
+                      installation and your OtaKit app ID. Registering here does not change your
+                      existing app or publish an update.
+                    </p>
+                  </Notice>
+                </>
+              )}
+            </fieldset>
+            <div className="mt-10 flex flex-wrap items-center justify-between gap-4 border-t border-border pt-6">
+              {index > 0 ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  disabled={busy}
+                  onClick={() => {
+                    setError(null);
+                    setStep(ONBOARDING_STEPS[index - 1]);
+                  }}
+                >
+                  <ArrowLeft className="size-4" />
+                  Back
+                </Button>
+              ) : (
+                <span className="text-xs text-muted-foreground">
+                  Progress saves when you continue.
+                </span>
+              )}
+              {step !== 'plans' && (
+                <Button
+                  type="submit"
+                  disabled={busy}
+                  className="ml-auto h-auto min-h-9 max-w-full shrink-0 whitespace-normal py-2"
+                >
+                  {busy ? <LoaderCircle className="size-4 animate-spin" /> : null}
+                  {unsupported
+                    ? 'Save and explore dashboard'
+                    : step === 'connect'
+                      ? needsCheckout
+                        ? 'Connect and continue to checkout'
+                        : 'Connect your app'
+                      : 'Continue'}
+                  {!busy && <ArrowRight className="size-4" />}
+                </Button>
+              )}
+            </div>
+          </form>
+        )}
+        <p className="mt-10 text-sm text-muted-foreground">
+          Need a hand?{' '}
+          <a href={SUPPORT_MAILTO} className="underline underline-offset-4 hover:text-foreground">
+            Contact us
+          </a>
+          .
+        </p>
+      </main>
+    </div>
+  );
+}
+
+function Notice({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-xl border border-border bg-muted/30 p-5 text-sm leading-6">
+      {children}
+    </div>
+  );
+}
+
+function Choices({
+  name,
+  label,
+  value,
+  options,
+  onChange,
+  compact = false,
+}: {
+  name: string;
+  label: string;
+  value?: string;
+  options: Array<[string, string, string?]>;
+  onChange: (value: string) => void;
+  compact?: boolean;
+}) {
+  return (
+    <fieldset>
+      <legend className="mb-3 text-sm font-medium">{label}</legend>
+      <div className={`grid gap-3 ${compact ? 'grid-cols-2 sm:grid-cols-3' : 'sm:grid-cols-2'}`}>
+        {options.map(([id, title, hint]) => (
+          <label
+            key={id}
+            className={`relative flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-colors focus-within:ring-2 focus-within:ring-ring ${value === id ? 'border-foreground bg-muted/50' : 'border-border hover:border-foreground/40'}`}
+          >
+            <input
+              className="mt-0.5 size-4 shrink-0 accent-foreground"
+              type="radio"
+              name={name}
+              value={id}
+              checked={value === id}
+              onChange={() => onChange(id)}
+            />
+            <span>
+              <span className="block text-sm font-medium">{title}</span>
+              {hint && (
+                <span className="mt-1 block text-xs leading-5 text-muted-foreground">{hint}</span>
+              )}
+            </span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+function UsageInput({
+  id,
+  label,
+  hint,
+  value,
+  max,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  hint: string;
+  value: number | null | undefined;
+  max: number;
+  onChange: (value: number | null | undefined) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <Label htmlFor={id}>{label}</Label>
+      <p id={`${id}-hint`} className="text-sm text-muted-foreground">
+        {hint}
+      </p>
+      <div className="flex flex-wrap items-center gap-4">
+        <Input
+          id={id}
+          className="max-w-52"
+          type="number"
+          inputMode="numeric"
+          min={0}
+          max={max}
+          step={1}
+          placeholder="e.g. 1000"
+          value={value ?? ''}
+          aria-describedby={`${id}-hint`}
+          onChange={(event) =>
+            onChange(event.target.value === '' ? undefined : Number(event.target.value))
+          }
+        />
+        <label className="flex cursor-pointer items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            className="size-4 accent-foreground"
+            checked={value === null}
+            onChange={(event) => onChange(event.target.checked ? null : undefined)}
+          />
+          Not sure yet
+        </label>
+      </div>
+    </div>
+  );
+}
+
+function CopyCode({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+  return (
+    <div className="mt-3">
+      <div className="flex items-start gap-3 rounded-lg bg-muted p-4">
+        <pre
+          tabIndex={0}
+          className="min-w-0 flex-1 overflow-x-auto rounded-sm text-sm leading-6 focus-visible:outline-2 focus-visible:outline-ring"
+        >
+          <code>{text}</code>
+        </pre>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Copy to clipboard"
+          onClick={async () => {
+            try {
+              await navigator.clipboard.writeText(text);
+              setCopied(true);
+              setCopyError(false);
+            } catch {
+              setCopyError(true);
+            }
+          }}
+        >
+          {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+        </Button>
+      </div>
+      <span className="text-xs text-muted-foreground" role="status">
+        {copyError ? 'Select and copy the text above.' : copied ? 'Copied' : ''}
+      </span>
+    </div>
+  );
+}

--- a/packages/console/app/onboarding/OnboardingFlow.tsx
+++ b/packages/console/app/onboarding/OnboardingFlow.tsx
@@ -833,11 +833,17 @@ function UsageInput({
           max={max}
           step={1}
           placeholder={placeholder}
-          value={value ?? ''}
+          value={value == null || Number.isNaN(value) ? '' : value}
           aria-invalid={invalid || undefined}
           aria-describedby={`${id}-hint${invalid ? ' onboarding-error' : ''}`}
           onChange={(event) =>
-            onChange(event.target.value === '' ? undefined : Number(event.target.value))
+            onChange(
+              event.target.validity.badInput
+                ? NaN
+                : event.target.value === ''
+                  ? undefined
+                  : Number(event.target.value),
+            )
           }
         />
       </div>

--- a/packages/console/app/onboarding/page.tsx
+++ b/packages/console/app/onboarding/page.tsx
@@ -5,10 +5,11 @@ import { SignupTracker } from '@/app/components/SignupTracker';
 import { db } from '@/lib/db';
 import { getOnboardingProfile } from '@/lib/services/onboarding-profile';
 import { getPlanLimits } from '@/lib/billing/config';
+import { isUnsupportedTechnology } from '@/lib/onboarding-profile';
 import { OnboardingFlow } from './OnboardingFlow';
 
 export const dynamic = 'force-dynamic';
-export const metadata = { title: 'Connect your app · OtaKit' };
+export const metadata = { title: 'Welcome to OtaKit' };
 
 export default async function OnboardingPage() {
   const data = await getDashboardInitialData();
@@ -22,7 +23,12 @@ export default async function OnboardingPage() {
       select: { planKey: true, isActive: true, freeDownloadsLimit: true },
     }),
   ]);
-  if (data.apps.length > 0 && !profile?.connectedApp) redirect('/dashboard');
+  if (
+    data.apps.length > 0 ||
+    (profile?.completedAt && isUnsupportedTechnology(profile.answers.technology))
+  ) {
+    redirect('/dashboard');
+  }
 
   return (
     <>

--- a/packages/console/app/onboarding/page.tsx
+++ b/packages/console/app/onboarding/page.tsx
@@ -1,0 +1,42 @@
+import { redirect } from 'next/navigation';
+
+import { getDashboardInitialData } from '@/app/dashboard/data';
+import { SignupTracker } from '@/app/components/SignupTracker';
+import { db } from '@/lib/db';
+import { getOnboardingProfile } from '@/lib/services/onboarding-profile';
+import { getPlanLimits } from '@/lib/billing/config';
+import { OnboardingFlow } from './OnboardingFlow';
+
+export const dynamic = 'force-dynamic';
+export const metadata = { title: 'Connect your app · OtaKit' };
+
+export default async function OnboardingPage() {
+  const data = await getDashboardInitialData();
+  if (data.activeOrganization.role !== 'owner' && data.activeOrganization.role !== 'admin') {
+    redirect('/dashboard');
+  }
+  const [profile, organization] = await Promise.all([
+    getOnboardingProfile(data.activeOrganization.id),
+    db.organization.findUniqueOrThrow({
+      where: { id: data.activeOrganization.id },
+      select: { planKey: true, isActive: true, freeDownloadsLimit: true },
+    }),
+  ]);
+  if (data.apps.length > 0 && !profile?.connectedApp) redirect('/dashboard');
+
+  return (
+    <>
+      <SignupTracker userId={data.user.id} createdAt={data.user.createdAt} />
+      <OnboardingFlow
+        key={data.activeOrganization.id}
+        organizationId={data.activeOrganization.id}
+        organizationName={data.activeOrganization.name}
+        initialProfile={profile}
+        billingEnabled={data.billingEnabled}
+        currentPlan={organization.planKey}
+        hasSubscription={organization.isActive || organization.planKey === 'enterprise'}
+        freeDownloads={getPlanLimits('free', organization.freeDownloadsLimit).downloads}
+      />
+    </>
+  );
+}

--- a/packages/console/lib/audit-log.ts
+++ b/packages/console/lib/audit-log.ts
@@ -6,6 +6,9 @@ import type { SessionContext } from './session';
 export type AuditAction =
   | 'organization.created'
   | 'organization.renamed'
+  | 'onboarding.updated'
+  | 'onboarding.completed'
+  | 'onboarding.skipped'
   | 'app.created'
   | 'bundle.uploaded'
   | 'bundle.deleted'

--- a/packages/console/lib/onboarding-profile.test.ts
+++ b/packages/console/lib/onboarding-profile.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appIdentifierError,
+  estimateMonthlyDownloads,
+  onboardingAnswersSchema,
+  onboardingRequestSchema,
+  onboardingStepError,
+  resumeOnboardingStep,
+  shouldShowOnboarding,
+  type OnboardingAnswers,
+} from './onboarding-profile';
+import { isValidAppSlug } from './validation';
+
+const answers: OnboardingAnswers = {
+  technology: 'capacitor',
+  framework: 'react',
+  appStage: 'testing',
+  otaProvider: 'none',
+  activeUsers: 1000,
+  updatesPerMonth: 4,
+  selectedPlan: 'free',
+};
+
+describe('guided onboarding validation', () => {
+  it('resumes at the first unanswered step instead of accepting a jump to connection', () => {
+    expect(resumeOnboardingStep({}, 'connect')).toBe('app');
+    expect(resumeOnboardingStep({ ...answers, otaProvider: undefined }, 'connect')).toBe('updates');
+    expect(resumeOnboardingStep({ ...answers, selectedPlan: undefined }, 'connect')).toBe('plans');
+    expect(resumeOnboardingStep(answers, 'connect')).toBe('connect');
+    expect(resumeOnboardingStep(answers, 'updates')).toBe('updates');
+  });
+
+  it('allows a known unsupported platform to finish without a pricing survey', () => {
+    expect(onboardingStepError({ technology: 'react_native' }, 'app')).toBeNull();
+    expect(resumeOnboardingStep({ technology: 'flutter' }, 'plans')).toBe('app');
+  });
+
+  it('distinguishes not answered, unknown, and a pre-launch audience of zero', () => {
+    expect(onboardingStepError({}, 'audience')).toBeTruthy();
+    expect(
+      onboardingStepError({ activeUsers: null, updatesPerMonth: null }, 'audience'),
+    ).toBeNull();
+    expect(onboardingStepError({ activeUsers: 0, updatesPerMonth: 2 }, 'audience')).toBeNull();
+    expect(estimateMonthlyDownloads({ activeUsers: null, updatesPerMonth: 4 })).toBeNull();
+    expect(estimateMonthlyDownloads({ activeUsers: 0, updatesPerMonth: 4 })).toBe(0);
+    expect(estimateMonthlyDownloads(answers)).toBe(4000);
+  });
+
+  it('rejects impossible usage, arbitrary fields, and invalid billing combinations', () => {
+    for (const activeUsers of [-1, 1.5, NaN, Infinity, 1_000_000_001, '1000']) {
+      expect(onboardingAnswersSchema.safeParse({ activeUsers }).success).toBe(false);
+    }
+    expect(
+      onboardingRequestSchema.safeParse({
+        action: 'save',
+        answers,
+        step: 'connect',
+        organizationId: 'another-org',
+      }).success,
+    ).toBe(false);
+    expect(
+      onboardingAnswersSchema.safeParse({ technology: 'capacitor', unknown: true }).success,
+    ).toBe(false);
+    expect(
+      onboardingStepError({ selectedPlan: 'starter', billingInterval: 'year' }, 'plans'),
+    ).toBeTruthy();
+    expect(onboardingStepError({ selectedPlan: 'pro' }, 'plans')).toBeTruthy();
+    expect(
+      onboardingStepError({ selectedPlan: 'pro', billingInterval: 'year' }, 'plans'),
+    ).toBeNull();
+  });
+
+  it.each([
+    'my-app',
+    'com.example.app',
+    'APP_2026',
+    'abc',
+    'x'.repeat(120),
+    'ab',
+    'a b',
+    '',
+    'a/b',
+    'x'.repeat(121),
+  ])('uses the existing app identifier rules for %s', (slug) => {
+    expect(appIdentifierError(slug) === null).toBe(isValidAppSlug(slug));
+  });
+
+  it('only intercepts owners with an empty workspace and unfinished onboarding', () => {
+    const input = { appCount: 0, role: 'owner', profile: null };
+    expect(shouldShowOnboarding(input)).toBe(true);
+    expect(shouldShowOnboarding({ ...input, appCount: 1 })).toBe(false);
+    expect(shouldShowOnboarding({ ...input, role: 'member' })).toBe(false);
+    expect(shouldShowOnboarding({ ...input, role: 'admin' })).toBe(false);
+    expect(
+      shouldShowOnboarding({ ...input, profile: { skippedAt: '2026-09-07', completedAt: null } }),
+    ).toBe(false);
+    expect(
+      shouldShowOnboarding({ ...input, profile: { skippedAt: null, completedAt: '2026-09-07' } }),
+    ).toBe(false);
+  });
+});

--- a/packages/console/lib/onboarding-profile.test.ts
+++ b/packages/console/lib/onboarding-profile.test.ts
@@ -37,7 +37,7 @@ describe('guided onboarding validation', () => {
   });
 
   it('distinguishes not answered, unknown, and a pre-launch audience of zero', () => {
-    expect(onboardingStepError({}, 'audience')).toBeTruthy();
+    expect(onboardingStepError({}, 'audience')).toBeNull();
     expect(
       onboardingStepError({ activeUsers: null, updatesPerMonth: null }, 'audience'),
     ).toBeNull();
@@ -45,6 +45,18 @@ describe('guided onboarding validation', () => {
     expect(estimateMonthlyDownloads({ activeUsers: null, updatesPerMonth: 4 })).toBeNull();
     expect(estimateMonthlyDownloads({ activeUsers: 0, updatesPerMonth: 4 })).toBe(0);
     expect(estimateMonthlyDownloads(answers)).toBe(4000);
+  });
+
+  it('allows blank audience estimates but reports invalid entered numbers', () => {
+    for (const activeUsers of [-1, 1.5, Infinity, 1_000_000_001]) {
+      expect(onboardingStepError({ activeUsers }, 'audience')).toContain('Monthly active users');
+    }
+    for (const updatesPerMonth of [-1, 1.5, 1001]) {
+      expect(onboardingStepError({ updatesPerMonth }, 'audience')).toContain('Monthly OTA updates');
+    }
+    expect(
+      onboardingStepError({ activeUsers: 1_000_000_000, updatesPerMonth: 1000 }, 'audience'),
+    ).toBeNull();
   });
 
   it('rejects impossible usage, arbitrary fields, and attempts to skip completion', () => {

--- a/packages/console/lib/onboarding-profile.test.ts
+++ b/packages/console/lib/onboarding-profile.test.ts
@@ -19,21 +19,21 @@ const answers: OnboardingAnswers = {
   otaProvider: 'none',
   activeUsers: 1000,
   updatesPerMonth: 4,
-  selectedPlan: 'free',
 };
 
 describe('guided onboarding validation', () => {
-  it('resumes at the first unanswered step instead of accepting a jump to connection', () => {
-    expect(resumeOnboardingStep({}, 'connect')).toBe('app');
-    expect(resumeOnboardingStep({ ...answers, otaProvider: undefined }, 'connect')).toBe('updates');
-    expect(resumeOnboardingStep({ ...answers, selectedPlan: undefined }, 'connect')).toBe('plans');
-    expect(resumeOnboardingStep(answers, 'connect')).toBe('connect');
+  it('resumes the saved question and corrects incomplete earlier answers', () => {
+    expect(resumeOnboardingStep({}, 'audience')).toBe('app');
+    expect(resumeOnboardingStep({ ...answers, otaProvider: undefined }, 'audience')).toBe(
+      'updates',
+    );
+    expect(resumeOnboardingStep(answers, 'audience')).toBe('audience');
     expect(resumeOnboardingStep(answers, 'updates')).toBe('updates');
   });
 
   it('allows a known unsupported platform to finish without a pricing survey', () => {
     expect(onboardingStepError({ technology: 'react_native' }, 'app')).toBeNull();
-    expect(resumeOnboardingStep({ technology: 'flutter' }, 'plans')).toBe('app');
+    expect(resumeOnboardingStep({ technology: 'flutter' }, 'audience')).toBe('app');
   });
 
   it('distinguishes not answered, unknown, and a pre-launch audience of zero', () => {
@@ -47,7 +47,7 @@ describe('guided onboarding validation', () => {
     expect(estimateMonthlyDownloads(answers)).toBe(4000);
   });
 
-  it('rejects impossible usage, arbitrary fields, and invalid billing combinations', () => {
+  it('rejects impossible usage, arbitrary fields, and attempts to skip completion', () => {
     for (const activeUsers of [-1, 1.5, NaN, Infinity, 1_000_000_001, '1000']) {
       expect(onboardingAnswersSchema.safeParse({ activeUsers }).success).toBe(false);
     }
@@ -55,7 +55,7 @@ describe('guided onboarding validation', () => {
       onboardingRequestSchema.safeParse({
         action: 'save',
         answers,
-        step: 'connect',
+        step: 'audience',
         organizationId: 'another-org',
       }).success,
     ).toBe(false);
@@ -63,12 +63,12 @@ describe('guided onboarding validation', () => {
       onboardingAnswersSchema.safeParse({ technology: 'capacitor', unknown: true }).success,
     ).toBe(false);
     expect(
-      onboardingStepError({ selectedPlan: 'starter', billingInterval: 'year' }, 'plans'),
-    ).toBeTruthy();
-    expect(onboardingStepError({ selectedPlan: 'pro' }, 'plans')).toBeTruthy();
+      onboardingRequestSchema.safeParse({ action: 'save', step: 'plans', answers }).success,
+    ).toBe(false);
     expect(
-      onboardingStepError({ selectedPlan: 'pro', billingInterval: 'year' }, 'plans'),
-    ).toBeNull();
+      onboardingRequestSchema.safeParse({ action: 'complete', answers, slug: 'my-app' }).success,
+    ).toBe(false);
+    expect(onboardingRequestSchema.safeParse({ action: 'complete', answers }).success).toBe(true);
   });
 
   it.each([

--- a/packages/console/lib/onboarding-profile.ts
+++ b/packages/console/lib/onboarding-profile.ts
@@ -55,11 +55,25 @@ export function onboardingStepError(
     if (!answers.appStage) return 'Choose where your app is today.';
   }
   if (step === 'updates' && !answers.otaProvider) return 'Choose your current update setup.';
-  if (step === 'audience') {
-    if (answers.activeUsers === undefined)
-      return 'Enter your monthly audience, or choose “Not sure yet”.';
-    if (answers.updatesPerMonth === undefined)
-      return 'Enter your update frequency, or choose “Not sure yet”.';
+  if (step === 'audience') return onboardingUsageError(answers)?.message ?? null;
+  return null;
+}
+
+export function onboardingUsageError(answers: OnboardingAnswers): {
+  field: 'activeUsers' | 'updatesPerMonth';
+  message: string;
+} | null {
+  for (const [field, label, max] of [
+    ['activeUsers', 'Monthly active users', 1_000_000_000],
+    ['updatesPerMonth', 'Monthly OTA updates', 1_000],
+  ] as const) {
+    const value = answers[field];
+    if (value != null && (!Number.isInteger(value) || value < 0 || value > max)) {
+      return {
+        field,
+        message: `${label} must be a whole number from 0 to ${max.toLocaleString('en-US')}. You can leave it blank if you’re not sure.`,
+      };
+    }
   }
   return null;
 }

--- a/packages/console/lib/onboarding-profile.ts
+++ b/packages/console/lib/onboarding-profile.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 
-export const ONBOARDING_STEPS = ['app', 'updates', 'audience', 'plans', 'connect'] as const;
+export const ONBOARDING_QUESTIONS = ['app', 'updates', 'audience'] as const;
+export type OnboardingQuestion = (typeof ONBOARDING_QUESTIONS)[number];
+export const ONBOARDING_STEPS = [...ONBOARDING_QUESTIONS, 'plans'] as const;
 export type OnboardingStep = (typeof ONBOARDING_STEPS)[number];
 
 export const onboardingAnswersSchema = z
@@ -21,8 +23,6 @@ export const onboardingAnswersSchema = z
       .enum(['search', 'ai', 'community', 'recommendation', 'launch_site', 'ad', 'other'])
       .optional(),
     sourceDetail: z.string().trim().max(120).optional(),
-    selectedPlan: z.enum(['free', 'starter', 'pro', 'enterprise']).optional(),
-    billingInterval: z.enum(['month', 'year']).optional(),
   })
   .strict();
 
@@ -33,7 +33,6 @@ export type OnboardingProfile = {
   step: OnboardingStep;
   completedAt: string | null;
   skippedAt: string | null;
-  connectedApp: { id: string; slug: string } | null;
 };
 
 export function isUnsupportedTechnology(technology: OnboardingAnswers['technology']) {
@@ -62,26 +61,18 @@ export function onboardingStepError(
     if (answers.updatesPerMonth === undefined)
       return 'Enter your update frequency, or choose “Not sure yet”.';
   }
-  if (step === 'plans') {
-    if (!answers.selectedPlan) return 'Choose a plan to get started.';
-    if (answers.selectedPlan === 'starter' && answers.billingInterval === 'year') {
-      return 'Starter is billed monthly.';
-    }
-    if (answers.selectedPlan === 'pro' && !answers.billingInterval)
-      return 'Choose monthly or yearly billing for Pro.';
-  }
   return null;
 }
 
 export function resumeOnboardingStep(
   answers: OnboardingAnswers,
-  saved: OnboardingStep,
-): OnboardingStep {
+  saved: OnboardingQuestion,
+): OnboardingQuestion {
   if (isUnsupportedTechnology(answers.technology)) return 'app';
-  for (const step of ONBOARDING_STEPS) {
+  for (const step of ONBOARDING_QUESTIONS) {
     if (step === saved || onboardingStepError(answers, step)) return step;
   }
-  return 'connect';
+  return 'audience';
 }
 
 export function shouldShowOnboarding(input: {
@@ -116,14 +107,13 @@ export const onboardingRequestSchema = z.discriminatedUnion('action', [
     .object({
       action: z.literal('save'),
       answers: onboardingAnswersSchema,
-      step: z.enum(ONBOARDING_STEPS),
+      step: z.enum(ONBOARDING_QUESTIONS),
     })
     .strict(),
   z
     .object({
       action: z.literal('complete'),
       answers: onboardingAnswersSchema,
-      slug: z.string().max(120).optional(),
     })
     .strict(),
   z.object({ action: z.literal('skip') }).strict(),

--- a/packages/console/lib/onboarding-profile.ts
+++ b/packages/console/lib/onboarding-profile.ts
@@ -1,0 +1,132 @@
+import { z } from 'zod';
+
+export const ONBOARDING_STEPS = ['app', 'updates', 'audience', 'plans', 'connect'] as const;
+export type OnboardingStep = (typeof ONBOARDING_STEPS)[number];
+
+export const onboardingAnswersSchema = z
+  .object({
+    technology: z
+      .enum(['capacitor', 'react_native', 'flutter', 'native', 'web', 'not_sure'])
+      .optional(),
+    framework: z.enum(['react', 'vue', 'angular', 'svelte', 'other', 'not_sure']).optional(),
+    appStage: z.enum(['live', 'testing', 'building', 'exploring']).optional(),
+    otaProvider: z
+      .enum(['none', 'appflow', 'capgo', 'capawesome', 'custom', 'other', 'not_sure'])
+      .optional(),
+    otherProvider: z.string().trim().max(120).optional(),
+    goal: z.enum(['start', 'migrate', 'cost', 'explore']).optional(),
+    activeUsers: z.number().int().min(0).max(1_000_000_000).nullable().optional(),
+    updatesPerMonth: z.number().int().min(0).max(1_000).nullable().optional(),
+    source: z
+      .enum(['search', 'ai', 'community', 'recommendation', 'launch_site', 'ad', 'other'])
+      .optional(),
+    sourceDetail: z.string().trim().max(120).optional(),
+    selectedPlan: z.enum(['free', 'starter', 'pro', 'enterprise']).optional(),
+    billingInterval: z.enum(['month', 'year']).optional(),
+  })
+  .strict();
+
+export type OnboardingAnswers = z.infer<typeof onboardingAnswersSchema>;
+
+export type OnboardingProfile = {
+  answers: OnboardingAnswers;
+  step: OnboardingStep;
+  completedAt: string | null;
+  skippedAt: string | null;
+  connectedApp: { id: string; slug: string } | null;
+};
+
+export function isUnsupportedTechnology(technology: OnboardingAnswers['technology']) {
+  return technology === 'react_native' || technology === 'flutter' || technology === 'native';
+}
+
+export function onboardingStepError(
+  answers: OnboardingAnswers,
+  step: OnboardingStep,
+): string | null {
+  if (step === 'app') {
+    if (!answers.technology) return 'Choose what your app is built with.';
+    if (isUnsupportedTechnology(answers.technology)) return null;
+    if (
+      (answers.technology === 'capacitor' || answers.technology === 'web') &&
+      !answers.framework
+    ) {
+      return 'Choose your web framework, or select “Not sure”.';
+    }
+    if (!answers.appStage) return 'Choose where your app is today.';
+  }
+  if (step === 'updates' && !answers.otaProvider) return 'Choose your current update setup.';
+  if (step === 'audience') {
+    if (answers.activeUsers === undefined)
+      return 'Enter your monthly audience, or choose “Not sure yet”.';
+    if (answers.updatesPerMonth === undefined)
+      return 'Enter your update frequency, or choose “Not sure yet”.';
+  }
+  if (step === 'plans') {
+    if (!answers.selectedPlan) return 'Choose a plan to get started.';
+    if (answers.selectedPlan === 'starter' && answers.billingInterval === 'year') {
+      return 'Starter is billed monthly.';
+    }
+    if (answers.selectedPlan === 'pro' && !answers.billingInterval)
+      return 'Choose monthly or yearly billing for Pro.';
+  }
+  return null;
+}
+
+export function resumeOnboardingStep(
+  answers: OnboardingAnswers,
+  saved: OnboardingStep,
+): OnboardingStep {
+  if (isUnsupportedTechnology(answers.technology)) return 'app';
+  for (const step of ONBOARDING_STEPS) {
+    if (step === saved || onboardingStepError(answers, step)) return step;
+  }
+  return 'connect';
+}
+
+export function shouldShowOnboarding(input: {
+  appCount: number;
+  role: string;
+  profile: Pick<OnboardingProfile, 'completedAt' | 'skippedAt'> | null;
+}) {
+  return (
+    input.appCount === 0 &&
+    input.role === 'owner' &&
+    !input.profile?.completedAt &&
+    !input.profile?.skippedAt
+  );
+}
+
+export function estimateMonthlyDownloads(answers: OnboardingAnswers): number | null {
+  if (answers.activeUsers == null || answers.updatesPerMonth == null) return null;
+  return answers.activeUsers * answers.updatesPerMonth;
+}
+
+export function appIdentifierError(value: string): string | null {
+  const slug = value.trim();
+  if (!slug) return 'Give your app an identifier, such as my-app.';
+  if (!/^[A-Za-z0-9._-]{3,120}$/.test(slug)) {
+    return 'Use 3–120 letters, numbers, dots, underscores, or hyphens. Spaces are not supported.';
+  }
+  return null;
+}
+
+export const onboardingRequestSchema = z.discriminatedUnion('action', [
+  z
+    .object({
+      action: z.literal('save'),
+      answers: onboardingAnswersSchema,
+      step: z.enum(ONBOARDING_STEPS),
+    })
+    .strict(),
+  z
+    .object({
+      action: z.literal('complete'),
+      answers: onboardingAnswersSchema,
+      slug: z.string().max(120).optional(),
+    })
+    .strict(),
+  z.object({ action: z.literal('skip') }).strict(),
+]);
+
+export type OnboardingRequest = z.infer<typeof onboardingRequestSchema>;

--- a/packages/console/lib/onboarding-profile.ts
+++ b/packages/console/lib/onboarding-profile.ts
@@ -116,7 +116,7 @@ export const onboardingRequestSchema = z.discriminatedUnion('action', [
       answers: onboardingAnswersSchema,
     })
     .strict(),
-  z.object({ action: z.literal('skip') }).strict(),
+  z.object({ action: z.literal('skip'), answers: onboardingAnswersSchema.optional() }).strict(),
 ]);
 
 export type OnboardingRequest = z.infer<typeof onboardingRequestSchema>;

--- a/packages/console/lib/services/apps.ts
+++ b/packages/console/lib/services/apps.ts
@@ -88,7 +88,7 @@ export async function createApp(input: {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
       throw new OtaKitServiceError(
         'APP_SLUG_CONFLICT',
-        'Slug already exists for this organization',
+        'This app identifier is already used in your workspace. Choose another, or open the existing app.',
         409,
       );
     }

--- a/packages/console/lib/services/onboarding-profile.integration.test.ts
+++ b/packages/console/lib/services/onboarding-profile.integration.test.ts
@@ -57,6 +57,20 @@ databaseDescribe('business onboarding (PostgreSQL integration)', () => {
     ).toBe(0);
   });
 
+  it('completes without requiring an audience or update-frequency estimate', async () => {
+    const unknownUsage = { ...answers };
+    delete unknownUsage.activeUsers;
+    delete unknownUsage.updatesPerMonth;
+    const profile = await updateOnboardingProfile(ctx, {
+      action: 'complete',
+      answers: unknownUsage,
+    });
+    expect(profile.completedAt).toEqual(expect.any(String));
+    expect(profile.answers.activeUsers).toBeUndefined();
+    expect(profile.answers.updatesPerMonth).toBeUndefined();
+    expect(shouldShowOnboarding({ appCount: 0, role: ctx.role, profile })).toBe(false);
+  });
+
   it('resumes an unfinished questionnaire and preserves skip across later draft saves', async () => {
     expect(await getOnboardingProfile(ctx.organizationId)).toBeNull();
     await updateOnboardingProfile(ctx, { action: 'save', answers, step: 'audience' });
@@ -156,7 +170,7 @@ databaseDescribe('business onboarding (PostgreSQL integration)', () => {
     await expect(
       updateOnboardingProfile(ctx, {
         action: 'complete',
-        answers: { ...answers, activeUsers: undefined },
+        answers: { ...answers, otaProvider: undefined },
       }),
     ).rejects.toMatchObject({ status: 400 });
     expect(await getOnboardingProfile(ctx.organizationId)).toBeNull();

--- a/packages/console/lib/services/onboarding-profile.integration.test.ts
+++ b/packages/console/lib/services/onboarding-profile.integration.test.ts
@@ -3,7 +3,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { db } from '@/lib/db';
 import type { SessionContext } from '@/lib/session';
-import type { OnboardingAnswers } from '@/lib/onboarding-profile';
+import { shouldShowOnboarding, type OnboardingAnswers } from '@/lib/onboarding-profile';
 import { getOnboardingProfile, updateOnboardingProfile } from './onboarding-profile';
 
 const databaseDescribe = process.env.RUN_DATABASE_TESTS === '1' ? describe : describe.skip;
@@ -15,10 +15,9 @@ const answers: OnboardingAnswers = {
   activeUsers: 2500,
   updatesPerMonth: 4,
   source: 'search',
-  selectedPlan: 'free',
 };
 
-databaseDescribe('onboarding profile (PostgreSQL integration)', () => {
+databaseDescribe('business onboarding (PostgreSQL integration)', () => {
   let ctx: SessionContext;
   beforeEach(async () => {
     const org = await db.organization.create({ data: { name: `Onboarding test ${randomUUID()}` } });
@@ -36,76 +35,21 @@ databaseDescribe('onboarding profile (PostgreSQL integration)', () => {
     await db.$disconnect();
   });
 
-  it('saves, resumes, and skips without creating an app or changing billing', async () => {
-    expect(await getOnboardingProfile(ctx.organizationId)).toBeNull();
-    await updateOnboardingProfile(ctx, { action: 'save', answers, step: 'plans' });
-    expect(await getOnboardingProfile(ctx.organizationId)).toMatchObject({
+  it('finishes the business questions without requiring an app or plan selection', async () => {
+    const profile = await updateOnboardingProfile(ctx, { action: 'complete', answers });
+    expect(profile).toMatchObject({
       answers,
       step: 'plans',
-      completedAt: null,
-      skippedAt: null,
-      connectedApp: null,
-    });
-    expect(await updateOnboardingProfile(ctx, { action: 'skip' })).toMatchObject({
-      answers,
-      skippedAt: expect.any(String),
-    });
-    expect(
-      await updateOnboardingProfile(ctx, { action: 'save', answers, step: 'plans' }),
-    ).toMatchObject({ skippedAt: null });
-    expect(await db.app.count({ where: { organizationId: ctx.organizationId } })).toBe(0);
-    expect(await db.organization.findUnique({ where: { id: ctx.organizationId } })).toMatchObject({
-      planKey: 'free',
-      isActive: false,
-    });
-  });
-
-  it('creates one app and one creation audit event under concurrent finish requests', async () => {
-    const profiles = await Promise.all(
-      Array.from({ length: 4 }, () =>
-        updateOnboardingProfile(ctx, {
-          action: 'complete',
-          answers: { ...answers, selectedPlan: 'pro', billingInterval: 'year' },
-          slug: 'my-app',
-        }),
-      ),
-    );
-    expect(new Set(profiles.map((profile) => profile.connectedApp?.id)).size).toBe(1);
-    expect(profiles.filter((profile) => profile.appCreated)).toHaveLength(1);
-    expect(profiles[0]).toMatchObject({
       completedAt: expect.any(String),
-      connectedApp: { slug: 'my-app' },
+      skippedAt: null,
     });
-    expect(await db.app.count({ where: { organizationId: ctx.organizationId } })).toBe(1);
-    expect(
-      await db.auditLog.count({
-        where: { organizationId: ctx.organizationId, action: 'app.created' },
-      }),
-    ).toBe(1);
+    const appCount = await db.app.count({ where: { organizationId: ctx.organizationId } });
+    expect(appCount).toBe(0);
+    expect(shouldShowOnboarding({ appCount, role: ctx.role, profile })).toBe(false);
     expect(await db.organization.findUnique({ where: { id: ctx.organizationId } })).toMatchObject({
       planKey: 'free',
       isActive: false,
     });
-    const lateSave = await updateOnboardingProfile(ctx, {
-      action: 'save',
-      answers: {},
-      step: 'app',
-    });
-    expect(lateSave.connectedApp).toEqual(profiles[0].connectedApp);
-    expect(lateSave.completedAt).toBe(profiles[0].completedAt);
-  });
-
-  it('reuses an app registered in the same workspace while onboarding was open', async () => {
-    const app = await db.app.create({
-      data: { organizationId: ctx.organizationId, slug: 'my-app' },
-    });
-    const profile = await updateOnboardingProfile(ctx, {
-      action: 'complete',
-      answers,
-      slug: 'my-app',
-    });
-    expect(profile.connectedApp?.id).toBe(app.id);
-    expect(profile.appCreated).toBe(false);
     expect(
       await db.auditLog.count({
         where: { organizationId: ctx.organizationId, action: 'app.created' },
@@ -113,72 +57,107 @@ databaseDescribe('onboarding profile (PostgreSQL integration)', () => {
     ).toBe(0);
   });
 
-  it('keeps identical identifiers and answers isolated between workspaces', async () => {
+  it('resumes an unfinished questionnaire and preserves skip across later draft saves', async () => {
+    expect(await getOnboardingProfile(ctx.organizationId)).toBeNull();
+    await updateOnboardingProfile(ctx, { action: 'save', answers, step: 'audience' });
+    const draft = await getOnboardingProfile(ctx.organizationId);
+    expect(draft).toMatchObject({ answers, step: 'audience', completedAt: null, skippedAt: null });
+    expect(shouldShowOnboarding({ appCount: 0, role: ctx.role, profile: draft })).toBe(true);
+    const skipped = await updateOnboardingProfile(ctx, { action: 'skip' });
+    const lateDraft = await updateOnboardingProfile(ctx, {
+      action: 'save',
+      answers,
+      step: 'audience',
+    });
+    expect(lateDraft.skippedAt).toBe(skipped.skippedAt);
+    expect(shouldShowOnboarding({ appCount: 0, role: ctx.role, profile: lateDraft })).toBe(false);
+    const completed = await updateOnboardingProfile(ctx, { action: 'complete', answers });
+    expect(completed).toMatchObject({
+      skippedAt: null,
+      completedAt: expect.any(String),
+      step: 'plans',
+    });
+  });
+
+  it('completes once under concurrent requests and never reopens on stale save/skip', async () => {
+    const profiles = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        updateOnboardingProfile(ctx, { action: 'complete', answers }),
+      ),
+    );
+    expect(new Set(profiles.map((profile) => profile.completedAt)).size).toBe(1);
+    expect(
+      await db.auditLog.count({
+        where: { organizationId: ctx.organizationId, action: 'onboarding.completed' },
+      }),
+    ).toBe(1);
+    const lateSave = await updateOnboardingProfile(ctx, {
+      action: 'save',
+      answers: {},
+      step: 'app',
+    });
+    const lateSkip = await updateOnboardingProfile(ctx, { action: 'skip' });
+    expect(lateSave).toEqual(profiles[0]);
+    expect(lateSkip).toEqual(profiles[0]);
+    expect(shouldShowOnboarding({ appCount: 0, role: ctx.role, profile: lateSave })).toBe(false);
+    expect(await db.app.count({ where: { organizationId: ctx.organizationId } })).toBe(0);
+  });
+
+  it('keeps survey answers isolated between workspaces', async () => {
     const other = await db.organization.create({ data: { name: 'Other onboarding workspace' } });
     try {
-      const first = await updateOnboardingProfile(ctx, {
-        action: 'complete',
-        answers,
-        slug: 'my-app',
-      });
-      const second = await updateOnboardingProfile(
+      await updateOnboardingProfile(ctx, { action: 'complete', answers });
+      await updateOnboardingProfile(
         { ...ctx, organizationId: other.id },
-        { action: 'complete', answers: { ...answers, otaProvider: 'none' }, slug: 'my-app' },
+        { action: 'complete', answers: { ...answers, otaProvider: 'none' } },
       );
-      expect(second.connectedApp?.id).not.toBe(first.connectedApp?.id);
       expect((await getOnboardingProfile(ctx.organizationId))?.answers.otaProvider).toBe('capgo');
+      expect((await getOnboardingProfile(other.id))?.answers.otaProvider).toBe('none');
     } finally {
       await db.organization.delete({ where: { id: other.id } });
     }
   });
 
-  it('records unsupported platforms without adding a fake app to the activation funnel', async () => {
+  it('records unsupported platforms without adding an app to the activation funnel', async () => {
     const profile = await updateOnboardingProfile(ctx, {
       action: 'complete',
       answers: { technology: 'flutter' },
     });
     expect(profile).toMatchObject({
       completedAt: expect.any(String),
-      connectedApp: null,
       answers: { technology: 'flutter' },
     });
     expect(await db.app.count({ where: { organizationId: ctx.organizationId } })).toBe(0);
-    await expect(
-      updateOnboardingProfile(ctx, {
-        action: 'complete',
-        answers: { technology: 'flutter' },
-        slug: 'fake-app',
-      }),
-    ).rejects.toMatchObject({ status: 400 });
+    expect(shouldShowOnboarding({ appCount: 0, role: ctx.role, profile })).toBe(false);
   });
 
-  it('rejects members and incomplete connections without writing data', async () => {
+  it('rejects members and unfinished answers without creating a profile', async () => {
     await expect(
       updateOnboardingProfile(
         { ...ctx, role: 'member' },
-        { action: 'save', answers, step: 'plans' },
+        { action: 'save', answers, step: 'audience' },
       ),
     ).rejects.toMatchObject({ status: 403 });
     await expect(
-      updateOnboardingProfile(ctx, { action: 'complete', answers: {}, slug: 'my-app' }),
+      updateOnboardingProfile(ctx, { action: 'complete', answers: {} }),
     ).rejects.toMatchObject({ status: 400 });
     await expect(
-      updateOnboardingProfile(ctx, { action: 'complete', answers, slug: 'a b' }),
+      updateOnboardingProfile(ctx, {
+        action: 'complete',
+        answers: { ...answers, activeUsers: undefined },
+      }),
     ).rejects.toMatchObject({ status: 400 });
     expect(await getOnboardingProfile(ctx.organizationId)).toBeNull();
   });
 
-  it('retains survey answers when the app is deleted', async () => {
-    const profile = await updateOnboardingProfile(ctx, {
-      action: 'complete',
-      answers,
-      slug: 'my-app',
+  it('stays completed after an app is connected and later deleted through the separate app flow', async () => {
+    const profile = await updateOnboardingProfile(ctx, { action: 'complete', answers });
+    const app = await db.app.create({
+      data: { organizationId: ctx.organizationId, slug: 'my-app' },
     });
-    await db.app.delete({ where: { id: profile.connectedApp!.id } });
-    expect(await getOnboardingProfile(ctx.organizationId)).toMatchObject({
-      connectedApp: null,
-      completedAt: expect.any(String),
-      answers,
-    });
+    await db.app.delete({ where: { id: app.id } });
+    const saved = await getOnboardingProfile(ctx.organizationId);
+    expect(saved).toEqual(profile);
+    expect(shouldShowOnboarding({ appCount: 0, role: ctx.role, profile: saved })).toBe(false);
   });
 });

--- a/packages/console/lib/services/onboarding-profile.integration.test.ts
+++ b/packages/console/lib/services/onboarding-profile.integration.test.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from 'node:crypto';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { db } from '@/lib/db';
+import type { SessionContext } from '@/lib/session';
+import type { OnboardingAnswers } from '@/lib/onboarding-profile';
+import { getOnboardingProfile, updateOnboardingProfile } from './onboarding-profile';
+
+const databaseDescribe = process.env.RUN_DATABASE_TESTS === '1' ? describe : describe.skip;
+const answers: OnboardingAnswers = {
+  technology: 'capacitor',
+  framework: 'react',
+  appStage: 'live',
+  otaProvider: 'capgo',
+  activeUsers: 2500,
+  updatesPerMonth: 4,
+  source: 'search',
+  selectedPlan: 'free',
+};
+
+databaseDescribe('onboarding profile (PostgreSQL integration)', () => {
+  let ctx: SessionContext;
+  beforeEach(async () => {
+    const org = await db.organization.create({ data: { name: `Onboarding test ${randomUUID()}` } });
+    ctx = {
+      organizationId: org.id,
+      userId: randomUUID(),
+      email: 'onboarding-test@example.test',
+      role: 'owner',
+    };
+  });
+  afterEach(async () => {
+    await db.organization.delete({ where: { id: ctx.organizationId } });
+  });
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it('saves, resumes, and skips without creating an app or changing billing', async () => {
+    expect(await getOnboardingProfile(ctx.organizationId)).toBeNull();
+    await updateOnboardingProfile(ctx, { action: 'save', answers, step: 'plans' });
+    expect(await getOnboardingProfile(ctx.organizationId)).toMatchObject({
+      answers,
+      step: 'plans',
+      completedAt: null,
+      skippedAt: null,
+      connectedApp: null,
+    });
+    expect(await updateOnboardingProfile(ctx, { action: 'skip' })).toMatchObject({
+      answers,
+      skippedAt: expect.any(String),
+    });
+    expect(
+      await updateOnboardingProfile(ctx, { action: 'save', answers, step: 'plans' }),
+    ).toMatchObject({ skippedAt: null });
+    expect(await db.app.count({ where: { organizationId: ctx.organizationId } })).toBe(0);
+    expect(await db.organization.findUnique({ where: { id: ctx.organizationId } })).toMatchObject({
+      planKey: 'free',
+      isActive: false,
+    });
+  });
+
+  it('creates one app and one creation audit event under concurrent finish requests', async () => {
+    const profiles = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        updateOnboardingProfile(ctx, {
+          action: 'complete',
+          answers: { ...answers, selectedPlan: 'pro', billingInterval: 'year' },
+          slug: 'my-app',
+        }),
+      ),
+    );
+    expect(new Set(profiles.map((profile) => profile.connectedApp?.id)).size).toBe(1);
+    expect(profiles.filter((profile) => profile.appCreated)).toHaveLength(1);
+    expect(profiles[0]).toMatchObject({
+      completedAt: expect.any(String),
+      connectedApp: { slug: 'my-app' },
+    });
+    expect(await db.app.count({ where: { organizationId: ctx.organizationId } })).toBe(1);
+    expect(
+      await db.auditLog.count({
+        where: { organizationId: ctx.organizationId, action: 'app.created' },
+      }),
+    ).toBe(1);
+    expect(await db.organization.findUnique({ where: { id: ctx.organizationId } })).toMatchObject({
+      planKey: 'free',
+      isActive: false,
+    });
+    const lateSave = await updateOnboardingProfile(ctx, {
+      action: 'save',
+      answers: {},
+      step: 'app',
+    });
+    expect(lateSave.connectedApp).toEqual(profiles[0].connectedApp);
+    expect(lateSave.completedAt).toBe(profiles[0].completedAt);
+  });
+
+  it('reuses an app registered in the same workspace while onboarding was open', async () => {
+    const app = await db.app.create({
+      data: { organizationId: ctx.organizationId, slug: 'my-app' },
+    });
+    const profile = await updateOnboardingProfile(ctx, {
+      action: 'complete',
+      answers,
+      slug: 'my-app',
+    });
+    expect(profile.connectedApp?.id).toBe(app.id);
+    expect(profile.appCreated).toBe(false);
+    expect(
+      await db.auditLog.count({
+        where: { organizationId: ctx.organizationId, action: 'app.created' },
+      }),
+    ).toBe(0);
+  });
+
+  it('keeps identical identifiers and answers isolated between workspaces', async () => {
+    const other = await db.organization.create({ data: { name: 'Other onboarding workspace' } });
+    try {
+      const first = await updateOnboardingProfile(ctx, {
+        action: 'complete',
+        answers,
+        slug: 'my-app',
+      });
+      const second = await updateOnboardingProfile(
+        { ...ctx, organizationId: other.id },
+        { action: 'complete', answers: { ...answers, otaProvider: 'none' }, slug: 'my-app' },
+      );
+      expect(second.connectedApp?.id).not.toBe(first.connectedApp?.id);
+      expect((await getOnboardingProfile(ctx.organizationId))?.answers.otaProvider).toBe('capgo');
+    } finally {
+      await db.organization.delete({ where: { id: other.id } });
+    }
+  });
+
+  it('records unsupported platforms without adding a fake app to the activation funnel', async () => {
+    const profile = await updateOnboardingProfile(ctx, {
+      action: 'complete',
+      answers: { technology: 'flutter' },
+    });
+    expect(profile).toMatchObject({
+      completedAt: expect.any(String),
+      connectedApp: null,
+      answers: { technology: 'flutter' },
+    });
+    expect(await db.app.count({ where: { organizationId: ctx.organizationId } })).toBe(0);
+    await expect(
+      updateOnboardingProfile(ctx, {
+        action: 'complete',
+        answers: { technology: 'flutter' },
+        slug: 'fake-app',
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('rejects members and incomplete connections without writing data', async () => {
+    await expect(
+      updateOnboardingProfile(
+        { ...ctx, role: 'member' },
+        { action: 'save', answers, step: 'plans' },
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+    await expect(
+      updateOnboardingProfile(ctx, { action: 'complete', answers: {}, slug: 'my-app' }),
+    ).rejects.toMatchObject({ status: 400 });
+    await expect(
+      updateOnboardingProfile(ctx, { action: 'complete', answers, slug: 'a b' }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(await getOnboardingProfile(ctx.organizationId)).toBeNull();
+  });
+
+  it('retains survey answers when the app is deleted', async () => {
+    const profile = await updateOnboardingProfile(ctx, {
+      action: 'complete',
+      answers,
+      slug: 'my-app',
+    });
+    await db.app.delete({ where: { id: profile.connectedApp!.id } });
+    expect(await getOnboardingProfile(ctx.organizationId)).toMatchObject({
+      connectedApp: null,
+      completedAt: expect.any(String),
+      answers,
+    });
+  });
+});

--- a/packages/console/lib/services/onboarding-profile.integration.test.ts
+++ b/packages/console/lib/services/onboarding-profile.integration.test.ts
@@ -96,11 +96,23 @@ databaseDescribe('business onboarding (PostgreSQL integration)', () => {
       answers: {},
       step: 'app',
     });
-    const lateSkip = await updateOnboardingProfile(ctx, { action: 'skip' });
+    const lateSkip = await updateOnboardingProfile(ctx, { action: 'skip', answers: {} });
     expect(lateSave).toEqual(profiles[0]);
     expect(lateSkip).toEqual(profiles[0]);
     expect(shouldShowOnboarding({ appCount: 0, role: ctx.role, profile: lateSave })).toBe(false);
     expect(await db.app.count({ where: { organizationId: ctx.organizationId } })).toBe(0);
+  });
+
+  it('skips with a partial draft in one write and retains answers when no draft is supplied', async () => {
+    const draft = { technology: 'capacitor' } as const;
+    const skipped = await updateOnboardingProfile(ctx, { action: 'skip', answers: draft });
+    expect(skipped).toMatchObject({
+      answers: draft,
+      skippedAt: expect.any(String),
+      completedAt: null,
+    });
+    expect(shouldShowOnboarding({ appCount: 0, role: ctx.role, profile: skipped })).toBe(false);
+    expect(await updateOnboardingProfile(ctx, { action: 'skip' })).toEqual(skipped);
   });
 
   it('keeps survey answers isolated between workspaces', async () => {

--- a/packages/console/lib/services/onboarding-profile.ts
+++ b/packages/console/lib/services/onboarding-profile.ts
@@ -4,8 +4,7 @@ import { db } from '@/lib/db';
 import { recordAuditLog, sessionActor } from '@/lib/audit-log';
 import type { SessionContext } from '@/lib/session';
 import {
-  ONBOARDING_STEPS,
-  appIdentifierError,
+  ONBOARDING_QUESTIONS,
   isUnsupportedTechnology,
   onboardingAnswersSchema,
   onboardingStepError,
@@ -15,33 +14,29 @@ import {
 } from '@/lib/onboarding-profile';
 import { OtaKitServiceError } from './errors';
 
-type ProfileRow = OrganizationOnboarding & { connectedApp: { id: string; slug: string } | null };
-const include = { connectedApp: { select: { id: true, slug: true } } } as const;
-
-function serialize(row: ProfileRow): OnboardingProfile {
+function serialize(row: OrganizationOnboarding): OnboardingProfile {
   const parsed = onboardingAnswersSchema.safeParse(row.answers);
   const answers = parsed.success ? parsed.data : {};
-  const step = ONBOARDING_STEPS.find((step) => step === row.step) ?? 'app';
+  const question = ONBOARDING_QUESTIONS.find((step) => step === row.step) ?? 'app';
   return {
     answers,
-    step: resumeOnboardingStep(answers, step),
+    step: row.completedAt ? 'plans' : resumeOnboardingStep(answers, question),
     completedAt: row.completedAt?.toISOString() ?? null,
     skippedAt: row.skippedAt?.toISOString() ?? null,
-    connectedApp: row.connectedApp,
   };
 }
 
 export async function getOnboardingProfile(
   organizationId: string,
 ): Promise<OnboardingProfile | null> {
-  const row = await db.organizationOnboarding.findUnique({ where: { organizationId }, include });
+  const row = await db.organizationOnboarding.findUnique({ where: { organizationId } });
   return row ? serialize(row) : null;
 }
 
 export async function updateOnboardingProfile(
   ctx: SessionContext,
   input: OnboardingRequest,
-): Promise<OnboardingProfile & { appCreated: boolean }> {
+): Promise<OnboardingProfile> {
   if (ctx.role !== 'owner' && ctx.role !== 'admin') {
     throw new OtaKitServiceError(
       'INSUFFICIENT_ROLE',
@@ -50,83 +45,48 @@ export async function updateOnboardingProfile(
     );
   }
   if (input.action === 'complete') {
-    const unsupported = isUnsupportedTechnology(input.answers.technology);
-    for (const step of unsupported ? (['app'] as const) : ONBOARDING_STEPS) {
-      const error = onboardingStepError(input.answers, step);
+    const questions = isUnsupportedTechnology(input.answers.technology)
+      ? (['app'] as const)
+      : ONBOARDING_QUESTIONS;
+    for (const question of questions) {
+      const error = onboardingStepError(input.answers, question);
       if (error) throw new OtaKitServiceError('INVALID_INPUT', error, 400);
-    }
-    if (!unsupported) {
-      const error = appIdentifierError(input.slug ?? '');
-      if (error) throw new OtaKitServiceError('INVALID_INPUT', error, 400);
-    } else if (input.slug) {
-      throw new OtaKitServiceError(
-        'INVALID_INPUT',
-        'OtaKit currently supports Capacitor apps. This stack cannot be connected.',
-        400,
-      );
     }
   }
 
   const result = await db.$transaction(async (tx) => {
-    // Serialize saves/completion for this workspace. Retried or concurrent finish
-    // requests must return the same app instead of creating duplicate records.
+    // A delayed save from another tab must not reopen completed onboarding.
     await tx.$executeRaw`INSERT INTO "OrganizationOnboarding" ("organizationId", "updatedAt")
       VALUES (${ctx.organizationId}, NOW()) ON CONFLICT ("organizationId") DO NOTHING`;
     await tx.$queryRaw`SELECT "organizationId" FROM "OrganizationOnboarding"
       WHERE "organizationId" = ${ctx.organizationId} FOR UPDATE`;
     const existing = await tx.organizationOnboarding.findUniqueOrThrow({
       where: { organizationId: ctx.organizationId },
-      include,
     });
-    if (existing.connectedAppId) return { row: existing, createdApp: false, changed: false };
+    if (existing.completedAt) return { row: existing, changed: false };
 
-    let createdApp = false;
     const data: Prisma.OrganizationOnboardingUpdateInput = {};
     if (input.action === 'skip') {
       data.skippedAt = existing.skippedAt ?? new Date();
     } else {
       data.answers = input.answers;
-      data.skippedAt = null;
       if (input.action === 'save') {
         data.step = resumeOnboardingStep(input.answers, input.step);
-        data.completedAt = null;
+        // An explicit return can resume a skipped questionnaire, but saving a
+        // draft must not make dashboard visits mandatory again.
       } else {
-        data.completedAt = existing.completedAt ?? new Date();
-        data.step = 'connect';
-        if (!isUnsupportedTechnology(input.answers.technology)) {
-          const slug = input.slug!.trim();
-          // Also tolerate registration through the CLI while this screen is open.
-          const inserted = await tx.app.createMany({
-            data: [{ organizationId: ctx.organizationId, slug }],
-            skipDuplicates: true,
-          });
-          createdApp = inserted.count > 0;
-          const app = await tx.app.findUniqueOrThrow({
-            where: { organizationId_slug: { organizationId: ctx.organizationId, slug } },
-            select: { id: true },
-          });
-          data.connectedApp = { connect: { id: app.id } };
-        }
+        data.completedAt = new Date();
+        data.skippedAt = null;
+        data.step = 'plans';
       }
     }
     const row = await tx.organizationOnboarding.update({
       where: { organizationId: ctx.organizationId },
       data,
-      include,
     });
-    return { row, createdApp, changed: true };
+    return { row, changed: true };
   });
 
-  if (result.createdApp && result.row.connectedApp) {
-    await recordAuditLog({
-      organizationId: ctx.organizationId,
-      actor: sessionActor(ctx),
-      action: 'app.created',
-      targetType: 'app',
-      targetId: result.row.connectedApp.id,
-      metadata: { slug: result.row.connectedApp.slug, source: 'onboarding' },
-    });
-  }
   if (result.changed) {
     await recordAuditLog({
       organizationId: ctx.organizationId,
@@ -142,5 +102,5 @@ export async function updateOnboardingProfile(
       metadata: { step: result.row.step },
     });
   }
-  return { ...serialize(result.row), appCreated: result.createdApp };
+  return serialize(result.row);
 }

--- a/packages/console/lib/services/onboarding-profile.ts
+++ b/packages/console/lib/services/onboarding-profile.ts
@@ -68,6 +68,7 @@ export async function updateOnboardingProfile(
     const data: Prisma.OrganizationOnboardingUpdateInput = {};
     if (input.action === 'skip') {
       data.skippedAt = existing.skippedAt ?? new Date();
+      if (input.answers) data.answers = input.answers;
     } else {
       data.answers = input.answers;
       if (input.action === 'save') {

--- a/packages/console/lib/services/onboarding-profile.ts
+++ b/packages/console/lib/services/onboarding-profile.ts
@@ -1,0 +1,146 @@
+import type { OrganizationOnboarding, Prisma } from '@prisma/client';
+
+import { db } from '@/lib/db';
+import { recordAuditLog, sessionActor } from '@/lib/audit-log';
+import type { SessionContext } from '@/lib/session';
+import {
+  ONBOARDING_STEPS,
+  appIdentifierError,
+  isUnsupportedTechnology,
+  onboardingAnswersSchema,
+  onboardingStepError,
+  resumeOnboardingStep,
+  type OnboardingProfile,
+  type OnboardingRequest,
+} from '@/lib/onboarding-profile';
+import { OtaKitServiceError } from './errors';
+
+type ProfileRow = OrganizationOnboarding & { connectedApp: { id: string; slug: string } | null };
+const include = { connectedApp: { select: { id: true, slug: true } } } as const;
+
+function serialize(row: ProfileRow): OnboardingProfile {
+  const parsed = onboardingAnswersSchema.safeParse(row.answers);
+  const answers = parsed.success ? parsed.data : {};
+  const step = ONBOARDING_STEPS.find((step) => step === row.step) ?? 'app';
+  return {
+    answers,
+    step: resumeOnboardingStep(answers, step),
+    completedAt: row.completedAt?.toISOString() ?? null,
+    skippedAt: row.skippedAt?.toISOString() ?? null,
+    connectedApp: row.connectedApp,
+  };
+}
+
+export async function getOnboardingProfile(
+  organizationId: string,
+): Promise<OnboardingProfile | null> {
+  const row = await db.organizationOnboarding.findUnique({ where: { organizationId }, include });
+  return row ? serialize(row) : null;
+}
+
+export async function updateOnboardingProfile(
+  ctx: SessionContext,
+  input: OnboardingRequest,
+): Promise<OnboardingProfile & { appCreated: boolean }> {
+  if (ctx.role !== 'owner' && ctx.role !== 'admin') {
+    throw new OtaKitServiceError(
+      'INSUFFICIENT_ROLE',
+      'Only workspace owners and admins can change onboarding.',
+      403,
+    );
+  }
+  if (input.action === 'complete') {
+    const unsupported = isUnsupportedTechnology(input.answers.technology);
+    for (const step of unsupported ? (['app'] as const) : ONBOARDING_STEPS) {
+      const error = onboardingStepError(input.answers, step);
+      if (error) throw new OtaKitServiceError('INVALID_INPUT', error, 400);
+    }
+    if (!unsupported) {
+      const error = appIdentifierError(input.slug ?? '');
+      if (error) throw new OtaKitServiceError('INVALID_INPUT', error, 400);
+    } else if (input.slug) {
+      throw new OtaKitServiceError(
+        'INVALID_INPUT',
+        'OtaKit currently supports Capacitor apps. This stack cannot be connected.',
+        400,
+      );
+    }
+  }
+
+  const result = await db.$transaction(async (tx) => {
+    // Serialize saves/completion for this workspace. Retried or concurrent finish
+    // requests must return the same app instead of creating duplicate records.
+    await tx.$executeRaw`INSERT INTO "OrganizationOnboarding" ("organizationId", "updatedAt")
+      VALUES (${ctx.organizationId}, NOW()) ON CONFLICT ("organizationId") DO NOTHING`;
+    await tx.$queryRaw`SELECT "organizationId" FROM "OrganizationOnboarding"
+      WHERE "organizationId" = ${ctx.organizationId} FOR UPDATE`;
+    const existing = await tx.organizationOnboarding.findUniqueOrThrow({
+      where: { organizationId: ctx.organizationId },
+      include,
+    });
+    if (existing.connectedAppId) return { row: existing, createdApp: false, changed: false };
+
+    let createdApp = false;
+    const data: Prisma.OrganizationOnboardingUpdateInput = {};
+    if (input.action === 'skip') {
+      data.skippedAt = existing.skippedAt ?? new Date();
+    } else {
+      data.answers = input.answers;
+      data.skippedAt = null;
+      if (input.action === 'save') {
+        data.step = resumeOnboardingStep(input.answers, input.step);
+        data.completedAt = null;
+      } else {
+        data.completedAt = existing.completedAt ?? new Date();
+        data.step = 'connect';
+        if (!isUnsupportedTechnology(input.answers.technology)) {
+          const slug = input.slug!.trim();
+          // Also tolerate registration through the CLI while this screen is open.
+          const inserted = await tx.app.createMany({
+            data: [{ organizationId: ctx.organizationId, slug }],
+            skipDuplicates: true,
+          });
+          createdApp = inserted.count > 0;
+          const app = await tx.app.findUniqueOrThrow({
+            where: { organizationId_slug: { organizationId: ctx.organizationId, slug } },
+            select: { id: true },
+          });
+          data.connectedApp = { connect: { id: app.id } };
+        }
+      }
+    }
+    const row = await tx.organizationOnboarding.update({
+      where: { organizationId: ctx.organizationId },
+      data,
+      include,
+    });
+    return { row, createdApp, changed: true };
+  });
+
+  if (result.createdApp && result.row.connectedApp) {
+    await recordAuditLog({
+      organizationId: ctx.organizationId,
+      actor: sessionActor(ctx),
+      action: 'app.created',
+      targetType: 'app',
+      targetId: result.row.connectedApp.id,
+      metadata: { slug: result.row.connectedApp.slug, source: 'onboarding' },
+    });
+  }
+  if (result.changed) {
+    await recordAuditLog({
+      organizationId: ctx.organizationId,
+      actor: sessionActor(ctx),
+      action:
+        input.action === 'skip'
+          ? 'onboarding.skipped'
+          : input.action === 'complete'
+            ? 'onboarding.completed'
+            : 'onboarding.updated',
+      targetType: 'organization',
+      targetId: ctx.organizationId,
+      metadata: { step: result.row.step },
+    });
+  }
+  return { ...serialize(result.row), appCreated: result.createdApp };
+}

--- a/packages/console/middleware.ts
+++ b/packages/console/middleware.ts
@@ -10,5 +10,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/dashboard/:path*'],
+  matcher: ['/dashboard/:path*', '/onboarding/:path*', '/onboard'],
 };

--- a/packages/console/prisma/migrations/20260907140000_organization_onboarding/migration.sql
+++ b/packages/console/prisma/migrations/20260907140000_organization_onboarding/migration.sql
@@ -3,17 +3,13 @@ CREATE TABLE "OrganizationOnboarding" (
     "version" INTEGER NOT NULL DEFAULT 1,
     "answers" JSONB NOT NULL DEFAULT '{}',
     "step" TEXT NOT NULL DEFAULT 'app',
-    "connectedAppId" TEXT,
     "completedAt" TIMESTAMP(3),
     "skippedAt" TIMESTAMP(3),
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
     CONSTRAINT "OrganizationOnboarding_pkey" PRIMARY KEY ("organizationId"),
-    CONSTRAINT "OrganizationOnboarding_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT "OrganizationOnboarding_connectedAppId_fkey" FOREIGN KEY ("connectedAppId") REFERENCES "App"("id") ON DELETE SET NULL ON UPDATE CASCADE
+    CONSTRAINT "OrganizationOnboarding_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
-
-CREATE UNIQUE INDEX "OrganizationOnboarding_connectedAppId_key" ON "OrganizationOnboarding"("connectedAppId");
 
 -- Insights uses a dedicated role that may not exist on self-hosted instances.
 DO $$

--- a/packages/console/prisma/migrations/20260907140000_organization_onboarding/migration.sql
+++ b/packages/console/prisma/migrations/20260907140000_organization_onboarding/migration.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "OrganizationOnboarding" (
+    "organizationId" TEXT NOT NULL,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "answers" JSONB NOT NULL DEFAULT '{}',
+    "step" TEXT NOT NULL DEFAULT 'app',
+    "connectedAppId" TEXT,
+    "completedAt" TIMESTAMP(3),
+    "skippedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "OrganizationOnboarding_pkey" PRIMARY KEY ("organizationId"),
+    CONSTRAINT "OrganizationOnboarding_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "OrganizationOnboarding_connectedAppId_fkey" FOREIGN KEY ("connectedAppId") REFERENCES "App"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "OrganizationOnboarding_connectedAppId_key" ON "OrganizationOnboarding"("connectedAppId");
+
+-- Insights uses a dedicated role that may not exist on self-hosted instances.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'otakit_insights_readonly') THEN
+        GRANT SELECT ON TABLE "OrganizationOnboarding" TO otakit_insights_readonly;
+    END IF;
+END $$;

--- a/packages/console/prisma/schema.prisma
+++ b/packages/console/prisma/schema.prisma
@@ -336,8 +336,6 @@ model OrganizationOnboarding {
   version        Int          @default(1)
   answers        Json         @default("{}")
   step           String       @default("app")
-  connectedAppId String?      @unique
-  connectedApp   App?         @relation(fields: [connectedAppId], references: [id], onDelete: SetNull)
   completedAt    DateTime?
   skippedAt      DateTime?
   createdAt      DateTime     @default(now())
@@ -408,16 +406,15 @@ model AuditLog {
 // ── App & bundles ───────────────────────────────────────────────────
 
 model App {
-  id             String                  @id @default(uuid())
-  organization   Organization            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  id             String          @id @default(uuid())
+  organization   Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   organizationId String
   slug           String
   bundles        Bundle[]
   releases       Release[]
   uploadSessions UploadSession[]
-  onboarding     OrganizationOnboarding?
-  createdAt      DateTime                @default(now())
-  updatedAt      DateTime                @updatedAt
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
 
   @@unique([organizationId, slug])
   @@index([organizationId, createdAt(sort: Desc)])

--- a/packages/console/prisma/schema.prisma
+++ b/packages/console/prisma/schema.prisma
@@ -301,22 +301,22 @@ enum ReleaseMutationStatus {
 // ── Organizations & membership ──────────────────────────────────────
 
 model Organization {
-  id                  String               @id @default(uuid())
+  id                  String                  @id @default(uuid())
   name                String
   // Billing (Polar)
-  planKey             PlanKey              @default(free)
+  planKey             PlanKey                 @default(free)
   // Persists the Free-tier allowance an organization was granted. Existing
   // Free organizations are grandfathered at 100k; new organizations get 5k.
-  freeDownloadsLimit  Int                  @default(5000)
-  isActive            Boolean              @default(false)
+  freeDownloadsLimit  Int                     @default(5000)
+  isActive            Boolean                 @default(false)
   polarCustomerId     String?
   polarSubscriptionId String?
   usagePeriodStart    DateTime?
   usageCalculatedAt   DateTime?
-  downloadsCount      Int                  @default(0)
-  usageBlocked        Boolean              @default(false)
-  overageEnabled      Boolean              @default(false)
-  warningSent         UsageWarningSent     @default(none)
+  downloadsCount      Int                     @default(0)
+  usageBlocked        Boolean                 @default(false)
+  overageEnabled      Boolean                 @default(false)
+  warningSent         UsageWarningSent        @default(none)
   // Relations
   apps                App[]
   apiKeys             OrganizationApiKey[]
@@ -324,9 +324,24 @@ model Organization {
   invites             OrganizationInvite[]
   auditLogs           AuditLog[]
   releaseMutations    ReleaseMutation[]
-  activeForUsers      User[]               @relation("UserActiveOrganization")
-  createdAt           DateTime             @default(now())
-  updatedAt           DateTime             @updatedAt
+  activeForUsers      User[]                  @relation("UserActiveOrganization")
+  onboarding          OrganizationOnboarding?
+  createdAt           DateTime                @default(now())
+  updatedAt           DateTime                @updatedAt
+}
+
+model OrganizationOnboarding {
+  organizationId String       @id
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  version        Int          @default(1)
+  answers        Json         @default("{}")
+  step           String       @default("app")
+  connectedAppId String?      @unique
+  connectedApp   App?         @relation(fields: [connectedAppId], references: [id], onDelete: SetNull)
+  completedAt    DateTime?
+  skippedAt      DateTime?
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
 }
 
 model OrganizationMember {
@@ -393,15 +408,16 @@ model AuditLog {
 // ── App & bundles ───────────────────────────────────────────────────
 
 model App {
-  id             String          @id @default(uuid())
-  organization   Organization    @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  id             String                  @id @default(uuid())
+  organization   Organization            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   organizationId String
   slug           String
   bundles        Bundle[]
   releases       Release[]
   uploadSessions UploadSession[]
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
+  onboarding     OrganizationOnboarding?
+  createdAt      DateTime                @default(now())
+  updatedAt      DateTime                @updatedAt
 
   @@unique([organizationId, slug])
   @@index([organizationId, createdAt(sort: Desc)])

--- a/packages/site/app/docs/setup/page.tsx
+++ b/packages/site/app/docs/setup/page.tsx
@@ -22,7 +22,7 @@ export default function SetupPage() {
 
       <Separator className="my-10" />
 
-      <H2>1. Create your app in the dashboard</H2>
+      <H2>1. Connect your app in the dashboard</H2>
       <P>
         Sign in to the{' '}
         <Link
@@ -31,7 +31,9 @@ export default function SetupPage() {
         >
           OtaKit dashboard
         </Link>
-        , create an app, and copy its OtaKit <Code>appId</Code>.
+        , choose “Connect your app”, and copy its OtaKit <Code>appId</Code>. If you already
+        registered your app during onboarding, use the ID shown there. Your app identifier can be a
+        simple label such as <Code>my-app</Code>; it does not need to match your native app ID.
       </P>
 
       <Separator className="my-10" />
@@ -64,8 +66,10 @@ const config: CapacitorConfig = {
 export default config;`}</Pre>
 
       <P>
-        Note: Your app must be published to the app store at least once with the OtaKit plugin
-        configured before it can receive updates!
+        Build and install the native app with the OtaKit plugin configured before testing OTA. A
+        local test build is enough to get started. To reach existing users, publish an App Store or
+        Google Play build containing the plugin; those users can receive OtaKit updates after
+        installing that build.
       </P>
 
       <P>

--- a/packages/site/app/docs/setup/page.tsx
+++ b/packages/site/app/docs/setup/page.tsx
@@ -30,10 +30,14 @@ export default function SetupPage() {
           className="font-medium text-foreground underline underline-offset-4"
         >
           OtaKit dashboard
-        </Link>
-        , choose “Connect your app”, and copy its OtaKit <Code>appId</Code>. The floating setup
-        panel also guides you through connecting your project. Your app identifier can be a simple
-        label such as <Code>my-app</Code>; it does not need to match your native app ID.
+        </Link>{' '}
+        and choose “Connect your app”. Give it a label that is unique in your workspace, such as{' '}
+        <Code>my-app</Code>; it does not need to match your native app ID.
+      </P>
+      <P>
+        OtaKit generates a separate app ID. Copy that generated value from the dashboard into{' '}
+        <Code>plugins.OtaKit.appId</Code>, not the label you entered. The floating setup panel
+        guides you through connecting your project.
       </P>
 
       <Separator className="my-10" />

--- a/packages/site/app/docs/setup/page.tsx
+++ b/packages/site/app/docs/setup/page.tsx
@@ -31,9 +31,9 @@ export default function SetupPage() {
         >
           OtaKit dashboard
         </Link>
-        , choose “Connect your app”, and copy its OtaKit <Code>appId</Code>. If you already
-        registered your app during onboarding, use the ID shown there. Your app identifier can be a
-        simple label such as <Code>my-app</Code>; it does not need to match your native app ID.
+        , choose “Connect your app”, and copy its OtaKit <Code>appId</Code>. The floating setup
+        panel also guides you through connecting your project. Your app identifier can be a simple
+        label such as <Code>my-app</Code>; it does not need to match your native app ID.
       </P>
 
       <Separator className="my-10" />

--- a/packages/site/public/llms.txt
+++ b/packages/site/public/llms.txt
@@ -74,7 +74,9 @@ This is the most simple, default hosted setup path.
 
 ### 1. Connect your app in the dashboard
 
-Sign in to the OtaKit dashboard , choose “Connect your app”, and copy its OtaKit `appId`. The floating setup panel also guides you through connecting your project. Your app identifier can be a simple label such as `my-app`; it does not need to match your native app ID.
+Sign in to the OtaKit dashboard and choose “Connect your app”. Give it a label that is unique in your workspace, such as `my-app`; it does not need to match your native app ID.
+
+OtaKit generates a separate app ID. Copy that generated value from the dashboard into `plugins.OtaKit.appId`, not the label you entered. The floating setup panel guides you through connecting your project.
 
 ### 2. Install the Capacitor plugin
 

--- a/packages/site/public/llms.txt
+++ b/packages/site/public/llms.txt
@@ -72,9 +72,9 @@ Set up the default hosted OtaKit flow in a Capacitor project.
 
 This is the most simple, default hosted setup path.
 
-### 1. Create your app in the dashboard
+### 1. Connect your app in the dashboard
 
-Sign in to the OtaKit dashboard , create an app, and copy its OtaKit `appId`.
+Sign in to the OtaKit dashboard , choose “Connect your app”, and copy its OtaKit `appId`. If you already registered your app during onboarding, use the ID shown there. Your app identifier can be a simple label such as `my-app`; it does not need to match your native app ID.
 
 ### 2. Install the Capacitor plugin
 
@@ -105,7 +105,7 @@ const config: CapacitorConfig = {
 export default config;
 ```
 
-Note: Your app must be published to the app store at least once with the OtaKit plugin configured before it can receive updates!
+Build and install the native app with the OtaKit plugin configured before testing OTA. A local test build is enough to get started. To reach existing users, publish an App Store or Google Play build containing the plugin; those users can receive OtaKit updates after installing that build.
 
 Optional: if you want something other than the hosted defaults, you can also set `launchPolicy`, `resumePolicy`, `runtimePolicy`, and `checkInterval`. See the Plugin API page for the full configuration surface.
 

--- a/packages/site/public/llms.txt
+++ b/packages/site/public/llms.txt
@@ -74,7 +74,7 @@ This is the most simple, default hosted setup path.
 
 ### 1. Connect your app in the dashboard
 
-Sign in to the OtaKit dashboard , choose “Connect your app”, and copy its OtaKit `appId`. If you already registered your app during onboarding, use the ID shown there. Your app identifier can be a simple label such as `my-app`; it does not need to match your native app ID.
+Sign in to the OtaKit dashboard , choose “Connect your app”, and copy its OtaKit `appId`. The floating setup panel also guides you through connecting your project. Your app identifier can be a simple label such as `my-app`; it does not need to match your native app ID.
 
 ### 2. Install the Capacitor plugin
 


### PR DESCRIPTION
New workspace owners reach an empty dashboard before OtaKit has any context about their app or update needs. This adds a saved, skippable business questionnaire followed by pricing: **App context → Update needs → Audience → Pricing**. Connecting the project, installing the updater, and shipping the first release remain in the existing floating setup panel.

The questionnaire records technology/framework, app stage, current OTA provider, optional goals, optional audience/update estimates, and optional acquisition source. Unsupported platforms get a compatibility explanation and can finish without an upsell. Pricing explains its download estimate and highlighted plan, preserves the existing catalog and grandfathered Free allowance, and provides a direct dashboard exit. Paid checkout shows loading feedback and returns to an inline status check that confirms the server's actual subscription for the expected workspace; brief subscription lag is retried automatically before offering manual retry, and failed checks can be retried. The floating launcher starts collapsed on checkout return so it does not cover this status on mobile.

**Completion is independent of app creation and payment.** Finishing the business questions saves `completedAt` before pricing. Completed or skipped profiles enter the dashboard with zero apps; unfinished profiles resume the saved question. Dashboard data is shared within each request to avoid duplicate database reads. The gate applies only to the app dashboard, leaving Settings, account/audit routes, and explicit pricing links reachable. Invalid numeric drafts cannot block skipping; valid partial answers are saved atomically. Delayed saves/skips cannot reopen a completed questionnaire. No App record or app-created conversion comes from the questionnaire. Existing apps, invited members/admins, and pending MCP authorization keep their entry paths.

The app dialog uses “Connect your app,” with identifier examples, inline errors, and Enter submission. Setup copy and documentation distinguish the chosen label from OtaKit's generated app ID and explain the native build needed to test OTA or reach existing users.

Validation: **124 console tests** passed against isolated PostgreSQL, plus repository typechecks, generated docs, lint/format, and the console production build. Browser/axe checks covered all question screens and mobile pricing, completion/reload/skip with zero apps, new empty workspaces from Settings, direct pricing, optional estimates and field-linked errors, mobile footer skip, slow checkout feedback, pending/failure/confirmed billing states, automatic retry after transient lag, incomplete numeric input, repeated URL parameters, workspace mismatch, existing paid plans, unsupported platforms, and the floating setup panel. External payment processing and hosted return were mocked; no purchase was made.

**Migration:** production migration `20260907140000_organization_onboarding` was applied and verified before merging. Other instances should apply it with `pnpm --filter @otakit/console db:migrate` before deploying. The additive migration creates a workspace profile without an App relation and grants SELECT to `otakit_insights_readonly` when present. Production has no pending or failed migrations, all recorded checksums match, and Insights has SELECT without write privileges on the new table. The answers are available to Insights through the database; this PR does not add an Insights screen.


