### PR TITLE
Fix missing setup helper after onboarding

### DIFF
--- a/packages/console/app/api/v1/organization/onboarding/route.test.ts
+++ b/packages/console/app/api/v1/organization/onboarding/route.test.ts
@@ -59,4 +59,28 @@ describe('onboarding route', () => {
       expect.objectContaining({ appId: undefined }),
     );
   });
+
+  it('rejects a stale workspace poll before reading another workspace’s progress', async () => {
+    const req = request();
+    req.headers.set('x-otakit-organization-id', 'org-2');
+
+    const response = await GET(req);
+
+    expect(response.status).toBe(409);
+    expect(mocks.getOnboardingSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('returns progress when the poll still matches the active workspace', async () => {
+    const req = request();
+    req.headers.set('x-otakit-organization-id', 'org-1');
+
+    const response = await GET(req);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ complete: false });
+    expect(mocks.getOnboardingSnapshot).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      appId: undefined,
+    });
+  });
 });

--- a/packages/console/app/api/v1/organization/onboarding/route.ts
+++ b/packages/console/app/api/v1/organization/onboarding/route.ts
@@ -11,6 +11,13 @@ export async function GET(request: NextRequest) {
   if (!ctx) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   }
+  const expectedOrganization = request.headers.get('x-otakit-organization-id');
+  if (expectedOrganization && expectedOrganization !== ctx.organizationId) {
+    return NextResponse.json(
+      { error: 'Your active workspace changed. Reload to continue.' },
+      { status: 409 },
+    );
+  }
 
   try {
     const appId = request.nextUrl.searchParams.get('appId')?.trim();

--- a/packages/console/app/components/setup/SetupStatusProvider.tsx
+++ b/packages/console/app/components/setup/SetupStatusProvider.tsx
@@ -5,9 +5,6 @@ import { createContext, useContext, useEffect, useState, type ReactNode } from '
 import { useStoredPreference } from '@/app/components/useStoredPreference';
 import type { OnboardingSnapshot } from '@/lib/services/onboarding';
 
-const DONE_STORAGE_KEY = 'otakit.setup.done';
-const DISMISS_STORAGE_KEY = 'otakit.setup.dismissed';
-
 /** Quick while a device is expected to report in, unhurried otherwise. */
 const POLL_WAITING_MS = 5_000;
 const POLL_IDLE_MS = 20_000;
@@ -37,10 +34,21 @@ export function useSetupStatus(): SetupStatus {
  * and this stops asking altogether — otherwise every dashboard visit, forever,
  * would pay an analytics query for a checklist that has been green for months.
  */
-export function SetupStatusProvider({ children }: { children: ReactNode }) {
+export function SetupStatusProvider({
+  userId,
+  organizationId,
+  children,
+}: {
+  userId: string;
+  organizationId: string;
+  children: ReactNode;
+}) {
   const [snapshot, setSnapshot] = useState<OnboardingSnapshot | null>(null);
-  const [doneValue, setDone] = useStoredPreference(DONE_STORAGE_KEY);
-  const [dismissedValue, setDismissed] = useStoredPreference(DISMISS_STORAGE_KEY);
+  // Legacy browser-wide flags cannot identify which account or workspace was
+  // finished or dismissed. Ignore them so a fresh workspace can show its help.
+  const scope = `${userId}:${organizationId}`;
+  const [doneValue, setDone] = useStoredPreference(`otakit.setup.done:${scope}`);
+  const [dismissedValue, setDismissed] = useStoredPreference(`otakit.setup.dismissed:${scope}`);
 
   const silent = doneValue === '1' || dismissedValue === '1';
 
@@ -57,9 +65,18 @@ export function SetupStatusProvider({ children }: { children: ReactNode }) {
         try {
           const response = await fetch('/api/v1/organization/onboarding', {
             signal: controller.signal,
+            headers: { 'x-otakit-organization-id': organizationId },
+            cache: 'no-store',
           });
+          if (response.status === 409 && !stopped) {
+            // Another tab switched workspaces. Its progress must not be saved
+            // as completion of the workspace still shown in this tab.
+            setSnapshot(null);
+            return;
+          }
           if (response.ok && !stopped) {
             const next = (await response.json()) as OnboardingSnapshot;
+            if (stopped) return;
             setSnapshot(next);
             if (next.complete) {
               setDone('1');
@@ -82,7 +99,7 @@ export function SetupStatusProvider({ children }: { children: ReactNode }) {
       controller.abort();
       if (timer) clearTimeout(timer);
     };
-  }, [silent, setDone]);
+  }, [silent, setDone, organizationId]);
 
   return (
     <SetupStatusContext.Provider

--- a/packages/console/app/dashboard/layout.tsx
+++ b/packages/console/app/dashboard/layout.tsx
@@ -12,7 +12,13 @@ export default async function DashboardLayout({ children }: { children: ReactNod
   return (
     <DashboardDataProvider initialData={initialData}>
       <SignupTracker userId={initialData.user.id} createdAt={initialData.user.createdAt} />
-      <SetupStatusProvider>{children}</SetupStatusProvider>
+      <SetupStatusProvider
+        key={`${initialData.user.id}:${initialData.activeOrganization.id}`}
+        userId={initialData.user.id}
+        organizationId={initialData.activeOrganization.id}
+      >
+        {children}
+      </SetupStatusProvider>
     </DashboardDataProvider>
   );
 }


### PR DESCRIPTION
The setup helper could disappear after business onboarding in a fresh workspace because a previous account or workspace had stored a browser-wide dismissed or completed flag. Store these preferences per user and workspace, ignore the ambiguous legacy flags, and reset the provider when that scope changes.

Setup polls now include the displayed workspace ID. If another tab changes the active workspace, the API rejects the stale poll before returning progress, preventing completion from being saved against the wrong workspace. Existing legacy dismissals may show the helper once again; completed setup is still confirmed by the server and hidden automatically.

Validation: reproduced the original failure in Chrome with both legacy flags set, then verified the helper appears after completed business onboarding on desktop and mobile, dismissal persists in its own workspace, another workspace and another account do not inherit dismissal, and stale workspace polls are rejected. Console unit and database tests, typecheck, ESLint, and Prettier passed. No database migration required.
