### PR TITLE
Preserve setup helper preferences for existing customers

### DIFF
--- a/packages/console/app/components/setup/SetupStatusProvider.tsx
+++ b/packages/console/app/components/setup/SetupStatusProvider.tsx
@@ -37,20 +37,50 @@ export function useSetupStatus(): SetupStatus {
 export function SetupStatusProvider({
   userId,
   organizationId,
+  hasExistingApps,
   children,
 }: {
   userId: string;
   organizationId: string;
+  hasExistingApps: boolean;
   children: ReactNode;
 }) {
   const [snapshot, setSnapshot] = useState<OnboardingSnapshot | null>(null);
-  // Legacy browser-wide flags cannot identify which account or workspace was
-  // finished or dismissed. Ignore them so a fresh workspace can show its help.
   const scope = `${userId}:${organizationId}`;
-  const [doneValue, setDone] = useStoredPreference(`otakit.setup.done:${scope}`);
-  const [dismissedValue, setDismissed] = useStoredPreference(`otakit.setup.dismissed:${scope}`);
+  const doneKey = `otakit.setup.done:${scope}`;
+  const dismissedKey = `otakit.setup.dismissed:${scope}`;
+  const [doneValue, setDone] = useStoredPreference(doneKey);
+  const [dismissedValue, setDismissed] = useStoredPreference(dismissedKey);
+  const [legacyDone] = useStoredPreference('otakit.setup.done');
+  const [legacyDismissed] = useStoredPreference('otakit.setup.dismissed');
 
-  const silent = doneValue === '1' || dismissedValue === '1';
+  // Keep existing customers' choices when migrating the browser-wide flags.
+  // Empty workspaces get explicit fresh values, so connecting their first app
+  // later cannot make an unrelated legacy flag hide the remaining setup steps.
+  const silent =
+    (doneValue ?? (hasExistingApps ? legacyDone : null)) === '1' ||
+    (dismissedValue ?? (hasExistingApps ? legacyDismissed : null)) === '1';
+
+  useEffect(() => {
+    try {
+      // Read storage directly here: the hydration snapshot can still be null
+      // even when a scoped preference already exists and must be preserved.
+      if (window.localStorage.getItem(doneKey) === null) {
+        setDone(
+          hasExistingApps && window.localStorage.getItem('otakit.setup.done') === '1' ? '1' : '0',
+        );
+      }
+      if (window.localStorage.getItem(dismissedKey) === null) {
+        setDismissed(
+          hasExistingApps && window.localStorage.getItem('otakit.setup.dismissed') === '1'
+            ? '1'
+            : '0',
+        );
+      }
+    } catch {
+      // Blocked browser storage leaves server-verified setup progress available.
+    }
+  }, [doneKey, dismissedKey, hasExistingApps, setDone, setDismissed]);
 
   useEffect(() => {
     if (silent) return;

--- a/packages/console/app/dashboard/layout.tsx
+++ b/packages/console/app/dashboard/layout.tsx
@@ -16,6 +16,7 @@ export default async function DashboardLayout({ children }: { children: ReactNod
         key={`${initialData.user.id}:${initialData.activeOrganization.id}`}
         userId={initialData.user.id}
         organizationId={initialData.activeOrganization.id}
+        hasExistingApps={initialData.apps.length > 0}
       >
         {children}
       </SetupStatusProvider>


### PR DESCRIPTION
Preserve existing customers’ hidden/finished setup-helper preferences when moving from browser-wide storage to account/workspace storage. Workspaces that already contain an app inherit their prior preference once; empty workspaces start with explicit fresh values, so connecting their first app later cannot accidentally hide the remaining setup steps.

Existing scoped preferences take precedence. This changes only setup-helper browser preferences; it requires no database migration and does not modify apps, releases, or billing.

Validation: all 158 repository tests and all package typechecks passed, as did ESLint and Prettier. Chrome checks cover legacy finished and dismissed preferences for existing apps (including reload), fresh onboarding with legacy flags, connecting the first app, independent workspace/account dismissal, stale workspace polls, and mobile rendering.

The broader browser suite also passed: existing-workspace Settings, account and audit routes, explicit pricing, onboarding completion/skip, checkout pending/error/retry/confirmed states, mismatched checkout workspace, and mobile accessibility. One initial mobile onboarding run timed out during simultaneous local test/build activity; a full rerun passed without code changes. GitHub CI and the Vercel preview build passed on the final commit.
